### PR TITLE
Increase max label limit from 10 to 15

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -308,7 +308,7 @@ const Todo: React.FC = ({}) => {
           <div className="flex-1 overflow-y-scroll pb-2">
             <Labels
               labels={data.labels}
-              limit={10}
+              limit={15}
               colors={colors}
               filters={data.filters}
               onFilter={updateFilters}


### PR DESCRIPTION
## Summary

Increases the maximum number of labels a user can create from 10 to 15, giving users more room to organize their tasks.

## Approach

- Updated the `limit` prop passed to the `<Labels>` component in `Todo.tsx` from `10` to `15`
- The `Labels` component already supports any numeric limit — only the prop value needed to change

Co-authored-by: Claude <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>
