### PR TITLE
Add storage adapter pattern for pluggable backends

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,7 @@
+# MCP relay (PR #102 - localhost relay for localStorage users)
+MCP_AUTH_TOKEN=
+VITE_MCP_RELAY_TOKEN=
+
+# Your Supabase project (what-todo.app identity + default data store)
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -373,9 +373,9 @@ test("mobile", async ({ page }) => {
     await expect(page.getByLabel("Compact mode")).toBeVisible()
   })
 
-  await test.step("task count is always visible in mobile", async () => {
+  await test.step("task count is hidden on mobile", async () => {
     await app.drawer.close()
-    await expect(app.header.progressBadge).toBeVisible()
+    await expect(app.header.progressBadge).toBeHidden()
   })
 
   await test.step("dark mode toggle accessible via drawer", async () => {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#151925" media="(prefers-color-scheme: dark)" />
-    <meta name="referrer" content="origin" />
+    <meta name="referrer" content="no-referrer-when-downgrade" />
 
     <!-- SEO -->
     <meta name="description" content="A simple, private todo app. Organize tasks with labels, pins, dark mode, and keyboard shortcuts. All data stays in your browser." />

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.19",
     "@meronex/icons": "^4.0.0",
+    "@supabase/supabase-js": "^2.101.1",
     "classnames": "^2.2.6",
     "framer-motion": "^12.38.0",
     "lodash-es": "^4.17.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@meronex/icons':
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.4)
+      '@supabase/supabase-js':
+        specifier: ^2.101.1
+        version: 2.101.1
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
@@ -971,6 +974,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.101.1':
+    resolution: {integrity: sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.101.1':
+    resolution: {integrity: sha512-OZWU7YtaG+NNNFZK8p/FuJ6gpq7pFyrG2fLOopP73HAIDHDGpOttPJapvO8ADu3RkqfQfkwrB354vPkSBbZ20A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.101.1':
+    resolution: {integrity: sha512-UW1RajH5jbZoK+ldAJ1I6VZ+HWwZ2oaKjEQ6Gn+AQ67CHQVxGl8wNQoLYyumbyaExm41I+wn7arulcY1eHeZJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.101.1':
+    resolution: {integrity: sha512-Oa6dno0OB9I+hv5do5zsZHbFu41ViZnE9IWjmkeeF/8fPmB5fWoHGqeTYEC3/0DAgtpUoFJa4FpvzFH0SBHo1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.101.1':
+    resolution: {integrity: sha512-WhTaUOBgeEvnKLy95Cdlp6+D5igSF/65yC727w1olxbet5nzUvMlajKUWyzNtQu2efrz2cQ7FcdVBdQqgT9YKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.101.1':
+    resolution: {integrity: sha512-Jnhm3LfuACwjIzvk2pfUbGQn7pa7hi6MFzfSyPrRYWVCCu69RPLCFyHSBl7HSBwadbQ3UZOznnD3gPca3ePrRA==}
+    engines: {node: '>=20.0.0'}
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -1793,6 +1823,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -3811,6 +3845,46 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.101.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.101.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.101.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.101.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.101.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.101.1':
+    dependencies:
+      '@supabase/auth-js': 2.101.1
+      '@supabase/functions-js': 2.101.1
+      '@supabase/postgrest-js': 2.101.1
+      '@supabase/realtime-js': 2.101.1
+      '@supabase/storage-js': 2.101.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -4736,6 +4810,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  iceberg-js@0.8.1: {}
 
   idb@7.1.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,36 @@
 import * as React from "react"
 
-// Context
 import StorageProvider from "./context/StorageContext"
 import { DarkModeProvider } from "./context/DarkModeContext"
 import { SettingsProvider } from "./context/SettingsContext"
+import { AuthProvider } from "./context/AuthContext"
+import DataConflictSheet from "./components/DataConflictSheet"
+import { useStorage } from "./context/StorageContext"
+
+function ConflictHandler() {
+  const { dataConflict, resolveConflict } = useStorage()
+  return (
+    <DataConflictSheet
+      open={!!dataConflict}
+      local={dataConflict?.local ?? null}
+      remote={dataConflict?.remote ?? null}
+      onUseRemote={() => resolveConflict("remote")}
+      onMerge={() => resolveConflict("merge")}
+    />
+  )
+}
 
 function ContextWrapper({ children }: React.PropsWithChildren<unknown>): any {
   return (
     <DarkModeProvider>
-      <SettingsProvider>
-        <StorageProvider>{children}</StorageProvider>
-      </SettingsProvider>
+      <AuthProvider>
+        <SettingsProvider>
+          <StorageProvider>
+            {children}
+            <ConflictHandler />
+          </StorageProvider>
+        </SettingsProvider>
+      </AuthProvider>
     </DarkModeProvider>
   )
 }

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -1,6 +1,7 @@
 // Types
 import { Action, Data, Label, Section, SectionData, Task } from "./index.d"
 
+import { StorageAdapter } from "./adapters/StorageAdapter"
 import colors from "./color-palette"
 import set from "lodash-es/set"
 
@@ -9,7 +10,7 @@ const uuid = () => crypto.randomUUID()
 type Item = Label
 type ItemKey = "labels"
 
-const isObj = (val: any) => {
+const isObj = (val: unknown) => {
   return typeof val === "object" && val !== null && !Array.isArray(val)
 }
 
@@ -17,20 +18,6 @@ const defaultLabels: Label[] = [
   { id: uuid(), title: "Work", color: colors[9].backgroundColor },
   { id: uuid(), title: "Personal", color: colors[1].backgroundColor }
 ]
-
-interface Browser {
-  storage: {
-    sync: {
-      get: () => any
-      clear: () => void
-    }
-    local: {
-      QUOTA_BYTES?: number | null
-      set: (data: any) => void
-      get: () => any
-    }
-  }
-}
 
 const defaultData: Data = {
   migrated: true,
@@ -48,62 +35,47 @@ const defaultData: Data = {
   }
 }
 
-const browser: Browser = {
-  storage: {
-    sync: {
-      get: () => ({}),
-      clear: () => undefined
-    },
-    local: {
-      QUOTA_BYTES: null,
-      set: data => localStorage.setItem("what-todo", JSON.stringify(data)),
-      get: () =>
-        JSON.parse(
-          localStorage.getItem("what-todo") || JSON.stringify(defaultData)
-        )
-    }
-  }
-}
-
 // Class
 class StorageManager {
   public defaultData: Data = defaultData
 
   public busy = false
 
-  public syncQueue: Array<(data: Data, ...args: any[]) => Data> = []
+  public syncQueue: Array<(data: Data, ...args: unknown[]) => Data> = []
 
   private subscriptions: Array<(data: Data) => void> = []
 
+  private adapter: StorageAdapter
+
+  constructor(adapter: StorageAdapter) {
+    this.adapter = adapter
+  }
+
+  /** Swap the storage backend at runtime (e.g. when connecting Supabase). */
+  setAdapter(adapter: StorageAdapter) {
+    this.adapter = adapter
+  }
+
   private async sync(newData: Data, action: Action): Promise<Data> {
-    if (this.busy && this.syncQueue.length) {
-      console.log(`>>> BUSY. Waiting...`, { queue: this.syncQueue })
+    try {
+      await this.adapter.set(newData)
+    } catch (err) {
+      console.error(`[StorageManager] sync failed (${action}):`, err)
+      return newData
     }
 
-    console.groupCollapsed(`Sync (${action})`)
-
-    console.time("sync")
-    console.log({ newData })
-    await browser.storage.local.set(newData)
-    console.timeEnd("sync")
-
-    console.time("emit subscriptions")
     this.subscriptions.forEach(fn => {
       if (typeof fn === "function") {
         fn(newData)
       }
     })
-    console.timeEnd("emit subscriptions")
 
-    console.debug(action, newData)
-    console.groupEnd()
     return newData
   }
 
-  private validateData(data: Record<string, any>): boolean {
-    const hasData = Object.keys(data).length > 0
-
-    return hasData
+  private validateData(data: Data | null): data is Data {
+    if (!data || typeof data !== "object") return false
+    return Object.keys(data).length > 0
   }
 
   private add(
@@ -184,30 +156,19 @@ class StorageManager {
     return JSON.parse(JSON.stringify(data))
   }
 
-  private async clearLegacyData() {
-    console.log("Clearing all legacy sync storage data")
-    try {
-      await browser.storage.sync.clear()
-    } catch {}
-  }
-
   private setBusyState() {
     this.busy = true
   }
 
   private unsetBusyState(data: Data) {
     this.busy = false
-    const unsynced = this.syncQueue.length
 
     while (this.syncQueue.length) {
       this.syncQueue.shift()!(data)
     }
-    if (unsynced) {
-      console.log(`>>> SYNC_QUEUE_CLEARED (${unsynced})`)
-    }
   }
 
-  private validateSyncData(data: any): Data {
+  private validateSyncData(data: Data): Data {
     if (typeof data !== "object" || Array.isArray(data) || !data) {
       return this.defaultData
     }
@@ -216,7 +177,7 @@ class StorageManager {
       return this.defaultData
     }
 
-    const returnValue: Data = data
+    const returnValue: Data = { ...data }
 
     // Validate filters
     if (!Array.isArray(data.filters)) {
@@ -236,46 +197,15 @@ class StorageManager {
     return returnValue
   }
 
-  private async transformSyncDataToLocalStorage(): Promise<Data | undefined> {
-    console.time("transformSyncDataToLocalStorage()")
-
-    try {
-      const oldData = await browser.storage.sync.get()
-
-      console.log({ oldData })
-
-      if (Object.keys(oldData).length < 1) {
-        await browser.storage.local.set({ migrated: false })
-
-        return undefined
-      }
-
-      const validatedData = this.validateSyncData(oldData)
-
-      // Update local storage
-      const newData = {
-        ...validatedData,
-        migrated: true
-      }
-
-      await this.sync(newData, "MIGRATE_DATA_FROM_SYNC")
-
-      // Clear old data
-      this.clearLegacyData()
-
-      return newData
-    } catch (error) {
-      console.error(error)
-      return undefined
-    } finally {
-      console.timeEnd("transformSyncDataToLocalStorage()")
-    }
-  }
-
-  private cleanData(data: Data) {
-    console.time("cleanData()")
+  /**
+   * Remove references to labels that no longer exist from tasks.
+   * Returns the cleaned data without persisting — the caller decides
+   * whether to sync, avoiding unnecessary write-backs on every read.
+   */
+  private cleanData(data: Data): { data: Data; changed: boolean } {
     const labelIds = data.labels?.map(x => x.id)
     const newData = this.cloneData(data)
+    let changed = false
 
     for (const [, tasks] of Object.entries(newData.tasks || {})) {
       for (let i = 0; i < tasks.length; i++) {
@@ -288,13 +218,13 @@ class StorageManager {
               labels: labels.filter(x => x !== label)
             }
             set(newData, `tasks.${this.getTaskKey(task)}.${i}`, newTask)
+            changed = true
           }
         }
       }
     }
 
-    console.timeEnd("cleanData()")
-    return this.sync(newData, "CLEAN_DATA")
+    return { data: newData, changed }
   }
 
   // ======================= PUBLIC API ============================== //
@@ -311,24 +241,20 @@ class StorageManager {
     let parsedData: Data = this.defaultData
 
     this.setBusyState()
-    console.groupCollapsed("GET_STORAGE_DATA")
-    console.time("getData()")
     try {
-      const data = await browser.storage.local.get()
-      console.log({ data })
+      const data = await this.adapter.get()
 
-      const valid = this.validateData(data)
-      parsedData = (valid ? data : this.defaultData) as Data
-      parsedData = await this.cleanData(parsedData)
-
-      if (!Boolean(parsedData.migrated)) {
-        // Migrate data from Release #1 from sync storage to local storage
-        const migratedData = await this.transformSyncDataToLocalStorage()
-
-        if (migratedData) parsedData = migratedData
+      if (this.validateData(data)) {
+        parsedData = this.validateSyncData(data)
       }
 
-      const filteringByMissingLabels = data.filters?.some(
+      const cleaned = this.cleanData(parsedData)
+      parsedData = cleaned.data
+      if (cleaned.changed) {
+        await this.sync(parsedData, "CLEAN_DATA")
+      }
+
+      const filteringByMissingLabels = parsedData.filters?.some(
         (filterId: string) => {
           return (
             (parsedData.labels || []).findIndex(({ id }) => filterId === id) < 0
@@ -346,18 +272,10 @@ class StorageManager {
         data: parsedData
       }
     } catch (error) {
-      console.error(error)
+      console.error("[StorageManager] getData failed:", error)
       return { data: parsedData }
     } finally {
-      console.timeEnd("getData()")
-      console.groupEnd()
-
       this.unsetBusyState(parsedData)
-      // return {
-      //   data: defaultData,
-      //   usage: null,
-      //   quota: bytesToSize(browser.storage.local.QUOTA_BYTES)
-      // }
     }
   }
 
@@ -389,7 +307,6 @@ class StorageManager {
   }
 
   // Tasks
-  // @sync()
   addTask(data: Data, task: Task): Data {
     const newTask: Task = {
       ...task,
@@ -406,7 +323,6 @@ class StorageManager {
     return newData
   }
 
-  // @sync()
   updateTask(data: Data, task: Task): Data {
     const newData = this.cloneData(data)
     const key = this.getTaskKey(task)
@@ -428,7 +344,6 @@ class StorageManager {
     return newData
   }
 
-  // @sync()
   removeTask(data: Data, task: Task): Data {
     const newData = this.cloneData(data)
     const key = this.getTaskKey(task)
@@ -465,7 +380,6 @@ class StorageManager {
     return data
   }
 
-  // @sync()
   moveTaskToToday(data: Data, task: Task): Data {
     const oldKey = this.getTaskKey(task)
     const todayKey = this.getTodayKey()

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -5,6 +5,8 @@ import { StorageAdapter } from "./adapters/StorageAdapter"
 import colors from "./color-palette"
 import set from "lodash-es/set"
 
+export const SCHEMA_VERSION = 1
+
 const uuid = () => crypto.randomUUID()
 
 type Item = Label
@@ -20,6 +22,7 @@ const defaultLabels: Label[] = [
 ]
 
 const defaultData: Data = {
+  schemaVersion: SCHEMA_VERSION,
   migrated: true,
   filters: [],
   tasks: {},
@@ -58,7 +61,7 @@ class StorageManager {
 
   private async sync(newData: Data, action: Action): Promise<Data> {
     try {
-      await this.adapter.set(newData)
+      await this.adapter.set({ ...newData, schemaVersion: SCHEMA_VERSION })
     } catch (err) {
       console.error(`[StorageManager] sync failed (${action}):`, err)
       return newData

--- a/src/adapters/AppSupabaseAdapter.ts
+++ b/src/adapters/AppSupabaseAdapter.ts
@@ -1,0 +1,64 @@
+import { Data } from "../index.d"
+import { StorageAdapter } from "./StorageAdapter"
+import { supabase } from "../lib/supabase"
+
+const TABLE = "todos"
+
+/**
+ * Stores data in the what-todo.app Supabase project.
+ * Used when the user is authenticated but has not connected
+ * their own Supabase project (the default authenticated tier).
+ *
+ * Each user has one row in the todos table, keyed by their
+ * auth.uid(). RLS ensures users can only access their own row.
+ */
+export class AppSupabaseAdapter implements StorageAdapter {
+  private get client() {
+    if (!supabase) throw new Error("Supabase is not configured")
+    return supabase
+  }
+
+  async get(): Promise<Data | null> {
+    const {
+      data: { user }
+    } = await this.client.auth.getUser()
+    if (!user) return null
+
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select("data")
+      .eq("user_id", user.id)
+      .maybeSingle()
+
+    if (error)
+      throw new Error(`AppSupabaseAdapter get failed: ${error.message}`)
+
+    return (data?.data as Data) ?? null
+  }
+
+  async set(newData: Data): Promise<void> {
+    const {
+      data: { user }
+    } = await this.client.auth.getUser()
+    if (!user) throw new Error("Not authenticated")
+
+    const { error } = await this.client.from(TABLE).upsert(
+      {
+        user_id: user.id,
+        data: newData,
+        updated_at: new Date().toISOString()
+      },
+      { onConflict: "user_id" }
+    )
+
+    if (error)
+      throw new Error(`AppSupabaseAdapter set failed: ${error.message}`)
+  }
+
+  async clear(): Promise<void> {
+    const { error } = await this.client.from(TABLE).delete().neq("user_id", "")
+
+    if (error)
+      throw new Error(`AppSupabaseAdapter clear failed: ${error.message}`)
+  }
+}

--- a/src/adapters/DebouncedAdapter.ts
+++ b/src/adapters/DebouncedAdapter.ts
@@ -1,0 +1,96 @@
+import { Data } from "../index.d"
+import { StorageAdapter } from "./StorageAdapter"
+
+/**
+ * Wraps any StorageAdapter with write debouncing.
+ *
+ * Rapid calls to set() are coalesced so only the last value is
+ * written after the debounce window. This prevents racing network
+ * requests when the user performs many actions in quick succession
+ * (e.g. checking off multiple tasks).
+ *
+ * Reads always go through to the inner adapter, but if a write is
+ * pending, get() returns the pending value to keep the UI consistent.
+ */
+export type SyncStatus = "idle" | "syncing" | "error"
+
+export interface SyncListener {
+  (status: SyncStatus, syncedAt?: Date): void
+}
+
+export class DebouncedAdapter implements StorageAdapter {
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private pendingData: Data | null = null
+  private writePromise: Promise<void> | null = null
+  private syncListener: SyncListener | null = null
+
+  constructor(
+    private inner: StorageAdapter,
+    private debounceMs = 300
+  ) {}
+
+  /** Register a callback that fires when sync status changes. */
+  onSyncChange(listener: SyncListener) {
+    this.syncListener = listener
+  }
+
+  async get(): Promise<Data | null> {
+    // If there's a pending write, return that value so the caller
+    // sees the latest data without waiting for the flush.
+    if (this.pendingData) return this.pendingData
+    return this.inner.get()
+  }
+
+  async set(data: Data): Promise<void> {
+    this.pendingData = data
+
+    if (this.timer) {
+      clearTimeout(this.timer)
+    }
+
+    this.timer = setTimeout(() => {
+      this.flush()
+    }, this.debounceMs)
+  }
+
+  async clear(): Promise<void> {
+    this.cancelPending()
+    return this.inner.clear()
+  }
+
+  testConnection?(): Promise<void> {
+    return this.inner.testConnection?.() ?? Promise.resolve()
+  }
+
+  /** Force-flush any pending write immediately. */
+  async flush(): Promise<void> {
+    if (!this.pendingData) return
+
+    const data = this.pendingData
+    this.pendingData = null
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+
+    this.syncListener?.("syncing")
+    try {
+      this.writePromise = this.inner.set(data)
+      await this.writePromise
+      this.writePromise = null
+      this.syncListener?.("idle", new Date())
+    } catch (err) {
+      this.writePromise = null
+      console.error("[DebouncedAdapter] write failed:", err)
+      this.syncListener?.("error")
+    }
+  }
+
+  private cancelPending() {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    this.pendingData = null
+  }
+}

--- a/src/adapters/LocalStorageAdapter.ts
+++ b/src/adapters/LocalStorageAdapter.ts
@@ -1,0 +1,28 @@
+import { Data } from "../index.d"
+import { StorageAdapter } from "./StorageAdapter"
+
+const STORAGE_KEY = "what-todo"
+
+/**
+ * Stores data in the browser's localStorage as a single JSON blob.
+ * This is the default backend and requires no setup.
+ */
+export class LocalStorageAdapter implements StorageAdapter {
+  async get(): Promise<Data | null> {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    try {
+      return JSON.parse(raw) as Data
+    } catch {
+      return null
+    }
+  }
+
+  async set(data: Data): Promise<void> {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  }
+
+  async clear(): Promise<void> {
+    localStorage.removeItem(STORAGE_KEY)
+  }
+}

--- a/src/adapters/StorageAdapter.ts
+++ b/src/adapters/StorageAdapter.ts
@@ -1,0 +1,27 @@
+import { Data } from "../index.d"
+
+/**
+ * Common interface for all storage backends.
+ *
+ * Both LocalStorageAdapter and SupabaseStorageAdapter conform to this
+ * contract so StorageManager can swap backends without changing any
+ * business logic.
+ */
+export interface StorageAdapter {
+  /** Read the full data blob. Returns null when no data exists yet. */
+  get(): Promise<Data | null>
+
+  /** Persist the full data blob, overwriting whatever was stored before. */
+  set(data: Data): Promise<void>
+
+  /** Delete all stored data. */
+  clear(): Promise<void>
+
+  /**
+   * Verify the adapter can connect to its backend.
+   * Throws with a descriptive message if the connection fails.
+   * Adapters that don't need connection testing (e.g. localStorage)
+   * can omit this — callers should check before invoking.
+   */
+  testConnection?(): Promise<void>
+}

--- a/src/adapters/SupabaseStorageAdapter.ts
+++ b/src/adapters/SupabaseStorageAdapter.ts
@@ -1,0 +1,138 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
+import { Data } from "../index.d"
+import { StorageAdapter } from "./StorageAdapter"
+
+const TABLE = "what_todo_data"
+
+/**
+ * Fixed row key — all devices share a single row.
+ *
+ * The intended use case is one Supabase project per user, so there
+ * is exactly one row. Cross-device sync works because every device
+ * reads and writes the same row. Security comes from the fact that
+ * only the user knows their project URL + anon key.
+ *
+ * Trade-off: last-write-wins. If two devices edit simultaneously,
+ * the last save wins. Acceptable for a personal todo app; real-time
+ * conflict resolution is a future enhancement.
+ */
+const ROW_ID = "default"
+
+/** Validate that a URL looks like a Supabase project URL. */
+export function isValidSupabaseUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return (
+      parsed.protocol === "https:" && parsed.hostname.endsWith(".supabase.co")
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Error thrown when a Supabase operation fails.
+ * Distinguishes network/backend errors from "no data" (null).
+ */
+export class SupabaseStorageError extends Error {
+  constructor(
+    operation: string,
+    public readonly cause: unknown
+  ) {
+    super(`Supabase ${operation} failed: ${cause}`)
+    this.name = "SupabaseStorageError"
+  }
+}
+
+/**
+ * Cache of Supabase clients keyed by URL+key to avoid creating
+ * duplicate clients, auth listeners, and realtime channels.
+ */
+const clientCache = new Map<string, SupabaseClient>()
+
+function getOrCreateClient(url: string, anonKey: string): SupabaseClient {
+  const cacheKey = `${url}::${anonKey}`
+  let client = clientCache.get(cacheKey)
+  if (!client) {
+    client = createClient(url, anonKey)
+    clientCache.set(cacheKey, client)
+  }
+  return client
+}
+
+/**
+ * Stores data in a user-provided Supabase instance.
+ *
+ * The full Data blob is kept as a single JSONB column so the schema
+ * stays simple and mirrors what localStorage already does. All
+ * devices share one row keyed by a fixed id ("default"), enabling
+ * cross-device access.
+ *
+ * Security model: the user's Supabase project URL and anon key act
+ * as the credentials. Only someone who knows both can read or write
+ * the data. The anon key is not public — the user enters it manually
+ * on each device they want to sync.
+ */
+export class SupabaseStorageAdapter implements StorageAdapter {
+  private client: SupabaseClient
+
+  constructor(supabaseUrl: string, supabaseAnonKey: string) {
+    if (!isValidSupabaseUrl(supabaseUrl)) {
+      throw new Error(
+        `Invalid Supabase URL: "${supabaseUrl}". ` +
+          "Expected https://<project>.supabase.co"
+      )
+    }
+
+    this.client = getOrCreateClient(supabaseUrl, supabaseAnonKey)
+  }
+
+  async get(): Promise<Data | null> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select("data")
+      .eq("id", ROW_ID)
+      .maybeSingle()
+
+    if (error) {
+      throw new SupabaseStorageError("get", error.message)
+    }
+
+    return (data?.data as Data) ?? null
+  }
+
+  async set(newData: Data): Promise<void> {
+    const { error } = await this.client.from(TABLE).upsert({
+      id: ROW_ID,
+      data: newData,
+      updated_at: new Date().toISOString()
+    })
+
+    if (error) {
+      throw new SupabaseStorageError("set", error.message)
+    }
+  }
+
+  async clear(): Promise<void> {
+    const { error } = await this.client.from(TABLE).delete().eq("id", ROW_ID)
+
+    if (error) {
+      throw new SupabaseStorageError("clear", error.message)
+    }
+  }
+
+  /**
+   * Test the connection by attempting a simple select.
+   * Throws if the table doesn't exist or the credentials are wrong.
+   */
+  async testConnection(): Promise<void> {
+    const { error } = await this.client.from(TABLE).select("id").limit(1)
+
+    if (error) {
+      throw new Error(
+        `Could not connect to Supabase: ${error.message}. ` +
+          `Make sure the "${TABLE}" table exists and RLS policies are configured.`
+      )
+    }
+  }
+}

--- a/src/adapters/__tests__/AppSupabaseAdapter.test.ts
+++ b/src/adapters/__tests__/AppSupabaseAdapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { Data } from "../../index.d"
+
+const mockUserId = "user-123"
+let rows: Record<string, unknown> = {}
+let shouldError: string | null = null
+let authUser: { id: string } | null = { id: mockUserId }
+
+vi.mock("../../lib/supabase", () => {
+  const from = (table: string) => ({
+    select: () => ({
+      eq: () => ({
+        maybeSingle: async () => {
+          if (shouldError)
+            return { data: null, error: { message: shouldError } }
+          return { data: rows[table] ?? null, error: null }
+        }
+      })
+    }),
+    upsert: async (payload: unknown) => {
+      if (shouldError) return { error: { message: shouldError } }
+      rows[table] = payload
+      return { error: null }
+    },
+    delete: () => ({
+      neq: async () => {
+        if (shouldError) return { error: { message: shouldError } }
+        delete rows[table]
+        return { error: null }
+      }
+    })
+  })
+
+  return {
+    supabase: {
+      from,
+      auth: {
+        getUser: async () => ({
+          data: { user: authUser }
+        })
+      }
+    }
+  }
+})
+
+const sampleData: Data = {
+  schemaVersion: 1,
+  filters: [],
+  tasks: {},
+  labels: [{ id: "1", title: "Work", color: "#000" }],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+describe("AppSupabaseAdapter", () => {
+  let adapter: import("../AppSupabaseAdapter").AppSupabaseAdapter
+
+  beforeEach(async () => {
+    rows = {}
+    shouldError = null
+    authUser = { id: mockUserId }
+    const { AppSupabaseAdapter } = await import("../AppSupabaseAdapter")
+    adapter = new AppSupabaseAdapter()
+  })
+
+  it("returns null when no data exists", async () => {
+    const result = await adapter.get()
+    expect(result).toBeNull()
+  })
+
+  it("stores and retrieves data", async () => {
+    await adapter.set(sampleData)
+    // Simulate what the DB returns — the stored payload
+    rows["todos"] = { data: sampleData }
+    const result = await adapter.get()
+    expect(result).toEqual(sampleData)
+  })
+
+  it("includes user_id in upsert payload", async () => {
+    await adapter.set(sampleData)
+    const stored = rows["todos"] as Record<string, unknown>
+    expect(stored.user_id).toBe(mockUserId)
+  })
+
+  it("throws when not authenticated", async () => {
+    authUser = null
+    await expect(adapter.set(sampleData)).rejects.toThrow("Not authenticated")
+  })
+
+  it("throws on get error", async () => {
+    rows["todos"] = { data: sampleData }
+    shouldError = "connection failed"
+    await expect(adapter.get()).rejects.toThrow("AppSupabaseAdapter get failed")
+  })
+
+  it("throws on set error", async () => {
+    shouldError = "write failed"
+    await expect(adapter.set(sampleData)).rejects.toThrow(
+      "AppSupabaseAdapter set failed"
+    )
+  })
+
+  it("clears data", async () => {
+    rows["todos"] = { data: sampleData }
+    await adapter.clear()
+    expect(rows["todos"]).toBeUndefined()
+  })
+})

--- a/src/adapters/__tests__/DebouncedAdapter.test.ts
+++ b/src/adapters/__tests__/DebouncedAdapter.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { DebouncedAdapter } from "../DebouncedAdapter"
+import { StorageAdapter } from "../StorageAdapter"
+import { Data } from "../../index.d"
+
+const sampleData: Data = {
+  filters: [],
+  tasks: {},
+  labels: [{ id: "1", title: "Work", color: "#000" }],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+class InMemoryAdapter implements StorageAdapter {
+  data: Data | null = null
+  setCalls = 0
+
+  async get() {
+    return this.data
+  }
+  async set(data: Data) {
+    this.data = structuredClone(data)
+    this.setCalls++
+  }
+  async clear() {
+    this.data = null
+  }
+}
+
+describe("DebouncedAdapter", () => {
+  let inner: InMemoryAdapter
+  let adapter: DebouncedAdapter
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    inner = new InMemoryAdapter()
+    adapter = new DebouncedAdapter(inner, 100)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not write immediately", async () => {
+    await adapter.set(sampleData)
+    expect(inner.setCalls).toBe(0)
+  })
+
+  it("writes after debounce period", async () => {
+    await adapter.set(sampleData)
+    vi.advanceTimersByTime(100)
+    // Wait for the flush promise to resolve
+    await vi.runAllTimersAsync()
+    expect(inner.setCalls).toBe(1)
+    expect(inner.data).toEqual(sampleData)
+  })
+
+  it("coalesces rapid writes", async () => {
+    const data1 = { ...sampleData, filters: ["a"] }
+    const data2 = { ...sampleData, filters: ["b"] }
+    const data3 = { ...sampleData, filters: ["c"] }
+
+    await adapter.set(data1)
+    await adapter.set(data2)
+    await adapter.set(data3)
+
+    await vi.runAllTimersAsync()
+    // Only one write should have happened
+    expect(inner.setCalls).toBe(1)
+    // With the latest data
+    expect(inner.data?.filters).toEqual(["c"])
+  })
+
+  it("returns pending data from get()", async () => {
+    await adapter.set(sampleData)
+    // Not flushed yet, but get() should return pending data
+    const result = await adapter.get()
+    expect(result).toEqual(sampleData)
+  })
+
+  it("returns inner data when nothing is pending", async () => {
+    inner.data = sampleData
+    const result = await adapter.get()
+    expect(result).toEqual(sampleData)
+  })
+
+  it("flush() writes immediately", async () => {
+    await adapter.set(sampleData)
+    await adapter.flush()
+    expect(inner.setCalls).toBe(1)
+  })
+
+  it("clear() cancels pending writes", async () => {
+    await adapter.set(sampleData)
+    await adapter.clear()
+
+    await vi.runAllTimersAsync()
+    expect(inner.setCalls).toBe(0)
+    expect(inner.data).toBeNull()
+  })
+})

--- a/src/adapters/__tests__/LocalStorageAdapter.test.ts
+++ b/src/adapters/__tests__/LocalStorageAdapter.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { LocalStorageAdapter } from "../LocalStorageAdapter"
+import { Data } from "../../index.d"
+
+const STORAGE_KEY = "what-todo"
+
+const sampleData: Data = {
+  filters: [],
+  tasks: {},
+  labels: [{ id: "1", title: "Work", color: "#000" }],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+describe("LocalStorageAdapter", () => {
+  let adapter: LocalStorageAdapter
+
+  beforeEach(() => {
+    localStorage.clear()
+    adapter = new LocalStorageAdapter()
+  })
+
+  it("returns null when nothing is stored", async () => {
+    const data = await adapter.get()
+    expect(data).toBeNull()
+  })
+
+  it("stores and retrieves data", async () => {
+    await adapter.set(sampleData)
+    const retrieved = await adapter.get()
+    expect(retrieved).toEqual(sampleData)
+  })
+
+  it("overwrites existing data on set", async () => {
+    await adapter.set(sampleData)
+
+    const updated = { ...sampleData, filters: ["label-1"] }
+    await adapter.set(updated)
+
+    const retrieved = await adapter.get()
+    expect(retrieved).toEqual(updated)
+  })
+
+  it("clears stored data", async () => {
+    await adapter.set(sampleData)
+    await adapter.clear()
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    const retrieved = await adapter.get()
+    expect(retrieved).toBeNull()
+  })
+
+  it("returns null for corrupted JSON", async () => {
+    localStorage.setItem(STORAGE_KEY, "{invalid json")
+    const data = await adapter.get()
+    expect(data).toBeNull()
+  })
+})

--- a/src/adapters/__tests__/StorageManager.test.ts
+++ b/src/adapters/__tests__/StorageManager.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import StorageManager from "../../StorageManager"
+import { StorageAdapter } from "../StorageAdapter"
+import { Data, Label } from "../../index.d"
+
+/** A minimal in-memory adapter for testing. */
+class InMemoryAdapter implements StorageAdapter {
+  private data: Data | null = null
+
+  async get() {
+    return this.data
+  }
+  async set(data: Data) {
+    this.data = structuredClone(data)
+  }
+  async clear() {
+    this.data = null
+  }
+
+  /** Seed data for a test. */
+  seed(data: Data) {
+    this.data = structuredClone(data)
+  }
+}
+
+describe("StorageManager with adapter", () => {
+  let adapter: InMemoryAdapter
+  let manager: StorageManager
+
+  beforeEach(() => {
+    adapter = new InMemoryAdapter()
+    manager = new StorageManager(adapter)
+  })
+
+  it("returns default data when adapter is empty", async () => {
+    const { data } = await manager.getData()
+    expect(data).toEqual(manager.defaultData)
+    expect(data.labels).toHaveLength(2)
+    expect(data.labels[0].title).toBe("Work")
+    expect(data.labels[1].title).toBe("Personal")
+    expect(data.tasks).toEqual({})
+    expect(data.filters).toEqual([])
+  })
+
+  it("does not write back to adapter when data is clean", async () => {
+    const seeded: Data = {
+      filters: [],
+      tasks: {},
+      labels: [{ id: "label-1", title: "Seeded", color: "#00f" }],
+      migrated: true,
+      sections: {
+        completed: { collapsed: true },
+        focus: {},
+        sidebar: { collapsed: false }
+      }
+    }
+    adapter.seed(seeded)
+
+    // getData should NOT trigger a write since no cleaning is needed
+    await manager.getData()
+
+    // Verify the adapter was not written to unnecessarily
+    // (the data should still match what we seeded, not default data)
+    const stored = await adapter.get()
+    expect(stored?.labels[0].title).toBe("Seeded")
+  })
+
+  it("persists data through the adapter", async () => {
+    const { data } = await manager.getData()
+
+    const label: Label = { id: "", title: "Test", color: "#f00" }
+    manager.addLabel(data, label)
+
+    // Verify it was written to the adapter
+    const stored = await adapter.get()
+    expect(stored).not.toBeNull()
+    expect(stored!.labels.some((l: Label) => l.title === "Test")).toBe(true)
+  })
+
+  it("can swap adapters at runtime", async () => {
+    const { data } = await manager.getData()
+
+    // Add a label via the first adapter
+    const newData = manager.addLabel(data, {
+      id: "",
+      title: "Swapped",
+      color: "#0f0"
+    })
+
+    // Create a new adapter and swap
+    const newAdapter = new InMemoryAdapter()
+    manager.setAdapter(newAdapter)
+
+    // The new adapter starts empty
+    const newAdapterData = await newAdapter.get()
+    expect(newAdapterData).toBeNull()
+
+    // Sync some data through the new adapter
+    manager.uploadData(newData)
+    const stored = await newAdapter.get()
+    expect(stored).not.toBeNull()
+    expect(stored!.labels.some((l: Label) => l.title === "Swapped")).toBe(true)
+  })
+
+  it("reads seeded data from the adapter", async () => {
+    const seeded: Data = {
+      filters: ["label-1"],
+      tasks: {},
+      labels: [{ id: "label-1", title: "Seeded", color: "#00f" }],
+      migrated: true,
+      sections: {
+        completed: { collapsed: true },
+        focus: {},
+        sidebar: { collapsed: false }
+      }
+    }
+    adapter.seed(seeded)
+
+    const { data } = await manager.getData()
+    expect(data.labels[0].title).toBe("Seeded")
+    expect(data.filters).toEqual(["label-1"])
+  })
+})

--- a/src/adapters/__tests__/SupabaseStorageAdapter.test.ts
+++ b/src/adapters/__tests__/SupabaseStorageAdapter.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { Data } from "../../index.d"
+
+// Shared mock state — reset in beforeEach
+let rows: Record<string, unknown> = {}
+let shouldError: string | null = null
+
+vi.mock("@supabase/supabase-js", () => {
+  const from = () => ({
+    select: () => ({
+      eq: (_col: string, val: string) => ({
+        maybeSingle: async () => {
+          if (shouldError)
+            return { data: null, error: { message: shouldError } }
+          const key = `what_todo_data:${val}`
+          return { data: rows[key] ?? null, error: null }
+        },
+        single: async () => {
+          if (shouldError)
+            return { data: null, error: { message: shouldError } }
+          const key = `what_todo_data:${val}`
+          return { data: rows[key] ?? null, error: null }
+        }
+      }),
+      limit: () =>
+        Promise.resolve(
+          shouldError
+            ? { data: null, error: { message: shouldError } }
+            : { data: [], error: null }
+        )
+    }),
+    upsert: async (row: Record<string, unknown>) => {
+      if (shouldError) return { error: { message: shouldError } }
+      const key = `what_todo_data:${row.id}`
+      rows[key] = row
+      return { error: null }
+    },
+    delete: () => ({
+      eq: async (_col: string, val: string) => {
+        if (shouldError) return { error: { message: shouldError } }
+        const key = `what_todo_data:${val}`
+        delete rows[key]
+        return { error: null }
+      }
+    })
+  })
+
+  return {
+    createClient: () => ({ from })
+  }
+})
+
+// Import after mock is set up
+import {
+  SupabaseStorageAdapter,
+  SupabaseStorageError
+} from "../SupabaseStorageAdapter"
+
+const sampleData: Data = {
+  filters: [],
+  tasks: {},
+  labels: [{ id: "1", title: "Work", color: "#000" }],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+function createAdapter() {
+  return new SupabaseStorageAdapter("https://test.supabase.co", "test-anon-key")
+}
+
+describe("SupabaseStorageAdapter", () => {
+  let adapter: SupabaseStorageAdapter
+
+  beforeEach(() => {
+    rows = {}
+    shouldError = null
+    adapter = createAdapter()
+  })
+
+  it("returns null when no data is stored", async () => {
+    const data = await adapter.get()
+    expect(data).toBeNull()
+  })
+
+  it("stores and retrieves data", async () => {
+    await adapter.set(sampleData)
+    const retrieved = await adapter.get()
+    expect(retrieved).toEqual(sampleData)
+  })
+
+  it("all instances share the same row", async () => {
+    // Simulate two devices connecting with the same credentials
+    const device1 = createAdapter()
+    const device2 = createAdapter()
+
+    await device1.set(sampleData)
+    const retrieved = await device2.get()
+    expect(retrieved).toEqual(sampleData)
+  })
+
+  it("last write wins across devices", async () => {
+    const device1 = createAdapter()
+    const device2 = createAdapter()
+
+    await device1.set(sampleData)
+    const updated = { ...sampleData, filters: ["label-1"] }
+    await device2.set(updated)
+
+    const result = await device1.get()
+    expect(result?.filters).toEqual(["label-1"])
+  })
+
+  it("clears stored data", async () => {
+    await adapter.set(sampleData)
+    await adapter.clear()
+    const retrieved = await adapter.get()
+    expect(retrieved).toBeNull()
+  })
+
+  it("testConnection does not throw for a valid setup", async () => {
+    await expect(adapter.testConnection()).resolves.toBeUndefined()
+  })
+
+  it("throws SupabaseStorageError on get() failure", async () => {
+    shouldError = "network timeout"
+    await expect(adapter.get()).rejects.toThrow(SupabaseStorageError)
+    await expect(adapter.get()).rejects.toThrow("network timeout")
+  })
+
+  it("throws SupabaseStorageError on set() failure", async () => {
+    shouldError = "permission denied"
+    await expect(adapter.set(sampleData)).rejects.toThrow(SupabaseStorageError)
+    await expect(adapter.set(sampleData)).rejects.toThrow("permission denied")
+  })
+
+  it("throws SupabaseStorageError on clear() failure", async () => {
+    shouldError = "server error"
+    await expect(adapter.clear()).rejects.toThrow(SupabaseStorageError)
+  })
+
+  it("throws on testConnection() failure with descriptive message", async () => {
+    shouldError = "relation does not exist"
+    await expect(adapter.testConnection()).rejects.toThrow(
+      /Could not connect to Supabase/
+    )
+    await expect(adapter.testConnection()).rejects.toThrow(/what_todo_data/)
+  })
+
+  it("rejects invalid Supabase URLs", () => {
+    expect(() => new SupabaseStorageAdapter("http://evil.com", "key")).toThrow(
+      /Invalid Supabase URL/
+    )
+  })
+})

--- a/src/adapters/__tests__/mergeData.test.ts
+++ b/src/adapters/__tests__/mergeData.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest"
+import { mergeData } from "../mergeData"
+import { Data } from "../../index.d"
+
+const makeData = (overrides: Partial<Data> = {}): Data => ({
+  schemaVersion: 1,
+  filters: [],
+  tasks: {},
+  labels: [],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  },
+  ...overrides
+})
+
+const task = (id: string, title: string) => ({
+  id,
+  title,
+  completed: false,
+  created_at: new Date("2025-01-01").toISOString(),
+  labels: []
+})
+
+const label = (id: string, title: string) => ({
+  id,
+  title,
+  color: "#000"
+})
+
+describe("mergeData", () => {
+  it("returns remote data when local is empty", () => {
+    const local = makeData()
+    const remote = makeData({
+      tasks: { "Wed Jan 01 2025": [task("r1", "Remote task")] }
+    })
+    const result = mergeData(local, remote)
+    expect(Object.values(result.tasks).flat()).toHaveLength(1)
+    expect(Object.values(result.tasks).flat()[0].title).toBe("Remote task")
+  })
+
+  it("returns local data when remote is empty", () => {
+    const local = makeData({
+      tasks: { "Wed Jan 01 2025": [task("l1", "Local task")] }
+    })
+    const remote = makeData()
+    const result = mergeData(local, remote)
+    expect(Object.values(result.tasks).flat()).toHaveLength(1)
+    expect(Object.values(result.tasks).flat()[0].title).toBe("Local task")
+  })
+
+  it("combines tasks from both sources", () => {
+    const local = makeData({
+      tasks: { "Wed Jan 01 2025": [task("l1", "Local task")] }
+    })
+    const remote = makeData({
+      tasks: { "Wed Jan 01 2025": [task("r1", "Remote task")] }
+    })
+    const result = mergeData(local, remote)
+    const all = Object.values(result.tasks).flat()
+    expect(all).toHaveLength(2)
+  })
+
+  it("deduplicates tasks by id, local wins on conflict", () => {
+    const sharedId = "shared"
+    const local = makeData({
+      tasks: {
+        "Wed Jan 01 2025": [task(sharedId, "Local version")]
+      }
+    })
+    const remote = makeData({
+      tasks: {
+        "Wed Jan 01 2025": [task(sharedId, "Remote version")]
+      }
+    })
+    const result = mergeData(local, remote)
+    const all = Object.values(result.tasks).flat()
+    expect(all).toHaveLength(1)
+    expect(all[0].title).toBe("Local version")
+  })
+
+  it("merges labels from both sources", () => {
+    const local = makeData({ labels: [label("l1", "Work")] })
+    const remote = makeData({ labels: [label("r1", "Personal")] })
+    const result = mergeData(local, remote)
+    expect(result.labels).toHaveLength(2)
+  })
+
+  it("deduplicates labels by id, local wins on conflict", () => {
+    const sharedId = "shared"
+    const local = makeData({ labels: [label(sharedId, "Local label")] })
+    const remote = makeData({ labels: [label(sharedId, "Remote label")] })
+    const result = mergeData(local, remote)
+    expect(result.labels).toHaveLength(1)
+    expect(result.labels[0].title).toBe("Local label")
+  })
+
+  it("prefers remote sections and filters", () => {
+    const local = makeData({ filters: ["l1"] })
+    const remote = makeData({
+      filters: ["r1"],
+      sections: {
+        completed: { collapsed: false },
+        focus: {},
+        sidebar: { collapsed: true }
+      }
+    })
+    const result = mergeData(local, remote)
+    expect(result.filters).toEqual(["r1"])
+    expect(result.sections?.completed?.collapsed).toBe(false)
+  })
+})

--- a/src/adapters/__tests__/migrateData.test.ts
+++ b/src/adapters/__tests__/migrateData.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { migrateData } from "../migrateData"
+import { StorageAdapter } from "../StorageAdapter"
+import { LocalStorageAdapter } from "../LocalStorageAdapter"
+import { Data } from "../../index.d"
+
+const sampleData: Data = {
+  filters: [],
+  tasks: {},
+  labels: [{ id: "1", title: "Work", color: "#000" }],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+/** In-memory adapter so source and target are truly independent. */
+class InMemoryAdapter implements StorageAdapter {
+  private data: Data | null = null
+
+  async get() {
+    return this.data
+  }
+  async set(data: Data) {
+    this.data = structuredClone(data)
+  }
+  async clear() {
+    this.data = null
+  }
+
+  seed(data: Data) {
+    this.data = structuredClone(data)
+  }
+}
+
+describe("migrateData", () => {
+  let source: InMemoryAdapter
+  let target: InMemoryAdapter
+
+  beforeEach(() => {
+    source = new InMemoryAdapter()
+    target = new InMemoryAdapter()
+  })
+
+  it("copies data from source to target", async () => {
+    source.seed(sampleData)
+
+    const result = await migrateData(source, target)
+
+    expect(result).toBe(true)
+    const retrieved = await target.get()
+    expect(retrieved).toEqual(sampleData)
+  })
+
+  it("returns false when source is empty", async () => {
+    const result = await migrateData(source, target)
+
+    expect(result).toBe(false)
+    const retrieved = await target.get()
+    expect(retrieved).toBeNull()
+  })
+
+  it("overwrites existing target data", async () => {
+    const oldData = { ...sampleData, filters: ["old-filter"] }
+    target.seed(oldData)
+    source.seed(sampleData)
+
+    await migrateData(source, target)
+
+    const retrieved = await target.get()
+    expect(retrieved).toEqual(sampleData)
+    expect(retrieved?.filters).toEqual([])
+  })
+
+  it("does not modify or clear the source adapter", async () => {
+    source.seed(sampleData)
+
+    await migrateData(source, target)
+
+    // Source must still have its original data intact
+    const sourceData = await source.get()
+    expect(sourceData).toEqual(sampleData)
+  })
+
+  it("propagates errors from source.get()", async () => {
+    const failingSource: StorageAdapter = {
+      get: () => Promise.reject(new Error("read failed")),
+      set: () => Promise.resolve(),
+      clear: () => Promise.resolve()
+    }
+
+    await expect(migrateData(failingSource, target)).rejects.toThrow(
+      "read failed"
+    )
+  })
+
+  it("propagates errors from target.set()", async () => {
+    source.seed(sampleData)
+
+    const failingTarget: StorageAdapter = {
+      get: () => Promise.resolve(null),
+      set: () => Promise.reject(new Error("write failed")),
+      clear: () => Promise.resolve()
+    }
+
+    await expect(migrateData(source, failingTarget)).rejects.toThrow(
+      "write failed"
+    )
+  })
+
+  it("preserves localStorage when migrating to a different adapter", async () => {
+    // Simulate the real connect flow: data lives in localStorage,
+    // we migrate to an in-memory "Supabase" target.
+    const localAdapter = new LocalStorageAdapter()
+    await localAdapter.set(sampleData)
+
+    const supabaseTarget = new InMemoryAdapter()
+    await migrateData(localAdapter, supabaseTarget)
+
+    // localStorage must still have the original data
+    const localData = await localAdapter.get()
+    expect(localData).toEqual(sampleData)
+
+    // Target got a copy
+    const targetData = await supabaseTarget.get()
+    expect(targetData).toEqual(sampleData)
+  })
+})

--- a/src/adapters/__tests__/supabaseConfig.test.ts
+++ b/src/adapters/__tests__/supabaseConfig.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  getSupabaseConfig,
+  setSupabaseConfig,
+  clearSupabaseConfig
+} from "../supabaseConfig"
+
+const CONFIG_KEY = "what-todo-supabase-config"
+
+describe("supabaseConfig", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("returns null when no config exists", () => {
+    expect(getSupabaseConfig()).toBeNull()
+  })
+
+  it("stores and retrieves config", () => {
+    setSupabaseConfig({
+      url: "https://test.supabase.co",
+      anonKey: "key123"
+    })
+
+    const config = getSupabaseConfig()
+    expect(config).toEqual({
+      url: "https://test.supabase.co",
+      anonKey: "key123"
+    })
+  })
+
+  it("clears config", () => {
+    setSupabaseConfig({
+      url: "https://test.supabase.co",
+      anonKey: "key123"
+    })
+    clearSupabaseConfig()
+
+    expect(getSupabaseConfig()).toBeNull()
+    expect(localStorage.getItem(CONFIG_KEY)).toBeNull()
+  })
+
+  it("returns null for corrupt JSON", () => {
+    localStorage.setItem(CONFIG_KEY, "not json")
+    expect(getSupabaseConfig()).toBeNull()
+  })
+
+  it("returns null for config with missing fields", () => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ url: "" }))
+    expect(getSupabaseConfig()).toBeNull()
+  })
+
+  it("throws for invalid Supabase URL", () => {
+    expect(() =>
+      setSupabaseConfig({ url: "http://evil.com", anonKey: "key" })
+    ).toThrow(/Invalid Supabase URL/)
+  })
+
+  it("throws for empty fields", () => {
+    expect(() => setSupabaseConfig({ url: "", anonKey: "" })).toThrow(
+      /required/
+    )
+  })
+})

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,10 @@
+export type { StorageAdapter } from "./StorageAdapter"
+export { LocalStorageAdapter } from "./LocalStorageAdapter"
+export {
+  SupabaseStorageAdapter,
+  SupabaseStorageError,
+  isValidSupabaseUrl
+} from "./SupabaseStorageAdapter"
+export { DebouncedAdapter } from "./DebouncedAdapter"
+export type { SyncStatus, SyncListener } from "./DebouncedAdapter"
+export { migrateData } from "./migrateData"

--- a/src/adapters/mergeData.ts
+++ b/src/adapters/mergeData.ts
@@ -1,0 +1,34 @@
+import { Data, Task, Label } from "../index.d"
+
+/**
+ * Merge two Data objects. Tasks and labels are deduplicated by ID.
+ * Remote sections/filters take precedence over local.
+ */
+export function mergeData(local: Data, remote: Data): Data {
+  const taskMap = new Map<string, Task>()
+
+  // Add remote tasks first, then local — local wins on conflict
+  for (const tasks of Object.values(remote.tasks ?? {})) {
+    for (const task of tasks) taskMap.set(task.id, task)
+  }
+  for (const tasks of Object.values(local.tasks ?? {})) {
+    for (const task of tasks) taskMap.set(task.id, task)
+  }
+
+  // Re-bucket merged tasks by their date key
+  const mergedTasks: Data["tasks"] = {}
+  for (const task of taskMap.values()) {
+    const key = new Date(task.created_at).toDateString()
+    mergedTasks[key] = [...(mergedTasks[key] ?? []), task]
+  }
+
+  const labelMap = new Map<string, Label>()
+  for (const label of remote.labels ?? []) labelMap.set(label.id, label)
+  for (const label of local.labels ?? []) labelMap.set(label.id, label)
+
+  return {
+    ...remote,
+    tasks: mergedTasks,
+    labels: Array.from(labelMap.values())
+  }
+}

--- a/src/adapters/migrateData.ts
+++ b/src/adapters/migrateData.ts
@@ -1,0 +1,20 @@
+import { StorageAdapter } from "./StorageAdapter"
+
+/**
+ * Copy data from one storage adapter to another.
+ * Returns true if data was migrated, false if the source was empty.
+ * Throws if either the read or write fails, so callers can handle
+ * the error and avoid leaving the user in a broken state.
+ */
+export async function migrateData(
+  source: StorageAdapter,
+  target: StorageAdapter
+): Promise<boolean> {
+  const data = await source.get()
+  if (!data) {
+    return false
+  }
+
+  await target.set(data)
+  return true
+}

--- a/src/adapters/supabaseConfig.ts
+++ b/src/adapters/supabaseConfig.ts
@@ -1,0 +1,58 @@
+/**
+ * Helpers for persisting the user's Supabase connection details in
+ * localStorage.  These are read on startup to decide which adapter
+ * to use and surfaced in the "Connect Supabase" panel.
+ *
+ * Note: The anon key is a *public* client-side credential in
+ * Supabase's auth model (it is shipped in every browser app that
+ * uses Supabase). Real authorization comes from Row Level Security
+ * policies on the database. Storing it in localStorage carries the
+ * same risk profile as any other client-side state — an XSS
+ * vulnerability could read it, but the anon key alone does not
+ * bypass RLS.
+ */
+
+import { isValidSupabaseUrl } from "./SupabaseStorageAdapter"
+
+const CONFIG_KEY = "what-todo-supabase-config"
+
+export interface SupabaseConfig {
+  url: string
+  anonKey: string
+}
+
+export function getSupabaseConfig(): SupabaseConfig | null {
+  const raw = localStorage.getItem(CONFIG_KEY)
+  if (!raw) return null
+  try {
+    const config = JSON.parse(raw) as SupabaseConfig
+    // Validate stored config is still well-formed
+    if (
+      typeof config.url !== "string" ||
+      typeof config.anonKey !== "string" ||
+      !config.url ||
+      !config.anonKey
+    ) {
+      return null
+    }
+    return config
+  } catch {
+    return null
+  }
+}
+
+export function setSupabaseConfig(config: SupabaseConfig): void {
+  if (!config.url || !config.anonKey) {
+    throw new Error("Supabase URL and anon key are required")
+  }
+  if (!isValidSupabaseUrl(config.url)) {
+    throw new Error(
+      `Invalid Supabase URL: "${config.url}". Expected https://<project>.supabase.co`
+    )
+  }
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+}
+
+export function clearSupabaseConfig(): void {
+  localStorage.removeItem(CONFIG_KEY)
+}

--- a/src/components/DataConflictSheet.tsx
+++ b/src/components/DataConflictSheet.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
+import { Data } from "../index.d"
+
+interface Props {
+  open: boolean
+  local: Data | null
+  remote: Data | null
+  onUseRemote: () => void
+  onMerge: () => void
+}
+
+function count(data: Data | null): number {
+  if (!data) return 0
+  return Object.values(data.tasks ?? {})
+    .flat()
+    .filter(t => !t.completed).length
+}
+
+type Choice = "remote" | "merge" | null
+
+function DataConflictSheet({
+  open,
+  local,
+  remote,
+  onUseRemote,
+  onMerge
+}: Props) {
+  const [choice, setChoice] = useState<Choice>(null)
+  const localCount = count(local)
+  const remoteCount = count(remote)
+
+  const handleConfirm = () => {
+    if (choice === "remote") onUseRemote()
+    if (choice === "merge") onMerge()
+    setChoice(null)
+  }
+
+  const confirmLabel =
+    choice === "merge"
+      ? `Merge ${localCount + remoteCount} tasks`
+      : `Use ${remoteCount} cloud task${remoteCount !== 1 ? "s" : ""}`
+
+  const confirmWarning =
+    choice === "remote"
+      ? `This will discard your ${localCount} local task${localCount !== 1 ? "s" : ""} permanently.`
+      : null
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="conflict-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 bg-black/40 z-60"
+              aria-hidden="true"
+            />
+            <motion.div
+              key="conflict-sheet"
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+              className="fixed bottom-0 left-0 right-0 z-60 bg-white dark:bg-navy-800 rounded-t-2xl shadow-xl"
+            >
+              <div className="flex justify-center pt-2 pb-1">
+                <div className="w-10 h-1 rounded-full bg-slate-300 dark:bg-navy-600" />
+              </div>
+              <div className="px-6 pt-2 pb-10">
+                <h2 className="text-base font-bold text-slate-700 dark:text-navy-100 mb-1">
+                  You have todos on this device
+                </h2>
+                <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-5">
+                  Your account already has saved data. What would you like to do
+                  with the todos on this device?
+                </p>
+
+                <div className="flex flex-col gap-3 mb-5">
+                  <button
+                    type="button"
+                    onClick={() => setChoice("merge")}
+                    className={`w-full text-left px-4 py-3 rounded-xl border-2 cursor-pointer transition-colors ${
+                      choice === "merge"
+                        ? "border-blue-400 dark:border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                        : "border-slate-200 dark:border-navy-600 hover:bg-slate-50 dark:hover:bg-navy-700"
+                    }`}
+                  >
+                    <p className="text-[13px] font-semibold text-slate-700 dark:text-navy-100 mb-0.5">
+                      Merge both
+                    </p>
+                    <p className="text-[12px] text-slate-500 dark:text-navy-400">
+                      Combine{" "}
+                      <span className="font-medium text-slate-600 dark:text-navy-300">
+                        {localCount} local task{localCount !== 1 ? "s" : ""}
+                      </span>{" "}
+                      with your{" "}
+                      <span className="font-medium text-slate-600 dark:text-navy-300">
+                        {remoteCount} cloud task{remoteCount !== 1 ? "s" : ""}
+                      </span>
+                    </p>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => setChoice("remote")}
+                    className={`w-full text-left px-4 py-3 rounded-xl border-2 cursor-pointer transition-colors ${
+                      choice === "remote"
+                        ? "border-blue-400 dark:border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                        : "border-slate-200 dark:border-navy-600 hover:bg-slate-50 dark:hover:bg-navy-700"
+                    }`}
+                  >
+                    <p className="text-[13px] font-semibold text-slate-700 dark:text-navy-100 mb-0.5">
+                      Use cloud data
+                    </p>
+                    <p className="text-[12px] text-slate-500 dark:text-navy-400">
+                      Keep your{" "}
+                      <span className="font-medium text-slate-600 dark:text-navy-300">
+                        {remoteCount} cloud task{remoteCount !== 1 ? "s" : ""}
+                      </span>{" "}
+                      and discard the local ones
+                    </p>
+                  </button>
+                </div>
+
+                {confirmWarning && (
+                  <p className="text-[12px] text-amber-600 dark:text-amber-400 mb-3">
+                    ⚠️ {confirmWarning}
+                  </p>
+                )}
+
+                <button
+                  type="button"
+                  disabled={!choice}
+                  onClick={handleConfirm}
+                  className="w-full px-4 py-2.5 text-[13px] font-semibold rounded-xl text-white transition-opacity disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                  style={{ background: "#3ecf8e" }}
+                >
+                  {choice ? confirmLabel : "Select an option"}
+                </button>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  )
+}
+
+export default DataConflictSheet

--- a/src/components/GoogleSignInButton.tsx
+++ b/src/components/GoogleSignInButton.tsx
@@ -1,0 +1,48 @@
+import { useAuth } from "../context/AuthContext"
+
+interface Props {
+  className?: string
+  onSignIn?: () => void
+}
+
+function GoogleIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  )
+}
+
+export function GoogleSignInButton({ className, onSignIn }: Props) {
+  const { signIn } = useAuth()
+
+  return (
+    <button
+      type="button"
+      onClick={() => (onSignIn ? onSignIn() : signIn("google"))}
+      className={
+        className ??
+        "flex items-center justify-center gap-2 bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 border border-slate-200 dark:border-navy-600 rounded-lg px-3 py-1.5 text-[13px] font-medium cursor-pointer hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
+      }
+    >
+      <GoogleIcon />
+      <span className="hidden md:inline">Sign in with Google</span>
+      <span className="md:hidden">Sign in</span>
+    </button>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,13 @@
-import { useCallback, useRef } from "react"
+import { useCallback, useRef, useState } from "react"
 import cx from "classnames"
 import MenuIcon from "@meronex/icons/fi/FiMenu"
 import SupabaseConnector from "./SupabaseConnector"
+import McpSetupSheet from "./McpSetupSheet"
+import { GoogleSignInButton } from "./GoogleSignInButton"
 import { useStorage } from "../context/StorageContext"
+import { useAuth } from "../context/AuthContext"
+import useOnClickOutside from "../hooks/onclickoutside"
+import { useSchemaCheck } from "../hooks/useSchemaCheck"
 
 async function seedFromFile() {
   try {
@@ -37,6 +42,125 @@ async function seedFromFile() {
   }
 }
 
+function UserMenu({
+  user,
+  isSupabaseConnected,
+  schemaOutdated,
+  onSignOut,
+  onOpenStorage
+}: {
+  user: { email?: string; user_metadata?: { avatar_url?: string } }
+  isSupabaseConnected: boolean
+  schemaOutdated: boolean
+  onSignOut: () => void
+  onOpenStorage: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(ref, () => setOpen(false))
+
+  const avatar = user.user_metadata?.avatar_url
+  const email = user.email
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        className="flex items-center bg-transparent border-none p-0 cursor-pointer"
+        onClick={() => setOpen(prev => !prev)}
+        aria-label="Account menu"
+      >
+        {avatar ? (
+          <img
+            src={avatar}
+            alt={email ?? "User"}
+            className="w-7 h-7 rounded-full"
+          />
+        ) : (
+          <span className="w-7 h-7 rounded-full bg-slate-200 dark:bg-navy-600 flex items-center justify-center text-xs font-semibold text-slate-600 dark:text-navy-300">
+            {(email ?? "?")[0].toUpperCase()}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-[calc(100%+8px)] w-64 bg-white dark:bg-navy-800 border border-slate-200 dark:border-navy-600 rounded-lg shadow-xl z-[100] overflow-hidden">
+          {email && (
+            <div className="px-3 py-2.5 border-b border-slate-100 dark:border-navy-700">
+              <p className="text-xs text-slate-400 dark:text-navy-500 truncate">
+                Signed in as
+              </p>
+              <p className="text-[13px] font-medium text-slate-700 dark:text-navy-100 truncate">
+                {email}
+              </p>
+            </div>
+          )}
+
+          <div className="border-b border-slate-100 dark:border-navy-700">
+            <p className="px-3 pt-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-navy-500">
+              Advanced
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                onOpenStorage()
+              }}
+              className="w-full text-left px-3 py-2 mb-1 text-[13px] text-slate-600 dark:text-navy-300 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors cursor-pointer bg-transparent border-none flex items-center justify-between rounded-lg"
+            >
+              <span>Connect custom Supabase</span>
+              <div className="flex items-center gap-1.5">
+                {schemaOutdated && (
+                  <span className="text-[10px] font-semibold text-amber-500">
+                    Update needed
+                  </span>
+                )}
+                {isSupabaseConnected && !schemaOutdated && (
+                  <span className="w-[7px] h-[7px] rounded-full bg-emerald-400 inline-block" />
+                )}
+              </div>
+            </button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              onSignOut()
+            }}
+            className="w-full text-left px-3 py-2.5 text-[13px] text-red-500 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors cursor-pointer bg-transparent border-none"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function McpPill() {
+  const [open, setOpen] = useState(false)
+  const { user } = useAuth()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="no-style hidden md:inline-flex text-[11px] font-medium text-slate-400 dark:text-navy-500 hover:text-slate-600 dark:hover:text-navy-300 transition-colors px-2.5 py-1 rounded-full border border-slate-200 dark:border-navy-600 mr-1"
+      >
+        /mcp
+      </button>
+      <McpSetupSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        apiToken={user?.id ?? null}
+      />
+    </>
+  )
+}
+
 function Header({
   className,
   onMenuClick,
@@ -66,13 +190,20 @@ function Header({
     }
   }, [])
 
+  const { user, isAuthenticated, supabaseConfigured, signIn, signOut } =
+    useAuth()
+
   const {
+    data,
     isSupabaseConnected,
     syncStatus,
     lastSyncedAt,
     connectSupabase,
     disconnectSupabase
   } = useStorage()
+
+  const [storageOpen, setStorageOpen] = useState(false)
+  const schemaOutdated = useSchemaCheck(data, isSupabaseConnected)
 
   return (
     <header
@@ -92,7 +223,7 @@ function Header({
         </h1>
         {typeof totalCount === "number" && (
           <span
-            className="text-xs font-semibold bg-slate-200 dark:bg-navy-700 text-slate-600 dark:text-navy-300 rounded-full px-2 py-0.5 leading-none"
+            className="hidden md:inline text-xs font-semibold bg-slate-200 dark:bg-navy-700 text-slate-600 dark:text-navy-300 rounded-full px-2 py-0.5 leading-none"
             style={{ verticalAlign: "baseline" }}
             aria-label={`${completedCount} of ${totalCount} tasks completed`}
             role="status"
@@ -101,19 +232,43 @@ function Header({
           </span>
         )}
         {date && (
-          <time className="text-xs text-slate-400 dark:text-navy-400 leading-none">
+          <time className="hidden md:inline text-xs text-slate-400 dark:text-navy-400 leading-none">
             {date}
           </time>
         )}
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <SupabaseConnector
-          isConnected={isSupabaseConnected}
-          syncStatus={syncStatus}
-          lastSyncedAt={lastSyncedAt}
-          onConnect={connectSupabase}
-          onDisconnect={disconnectSupabase}
-        />
+      <div className="flex items-center gap-3">
+        {isAuthenticated && user ? (
+          <div className="flex items-center gap-3">
+            <McpPill />
+            <SupabaseConnector
+              isConnected={isSupabaseConnected}
+              isAuthenticated={isAuthenticated}
+              userEmail={user?.email ?? null}
+              syncStatus={syncStatus}
+              lastSyncedAt={lastSyncedAt}
+              onConnect={connectSupabase}
+              onDisconnect={disconnectSupabase}
+              onSignIn={signIn}
+              onSignOut={signOut}
+              schemaOutdated={schemaOutdated}
+              externalOpen={storageOpen}
+              onExternalOpenChange={setStorageOpen}
+            />
+            <UserMenu
+              user={user}
+              isSupabaseConnected={isSupabaseConnected}
+              schemaOutdated={schemaOutdated}
+              onSignOut={signOut}
+              onOpenStorage={() => setStorageOpen(true)}
+            />
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <McpPill />
+            {supabaseConfigured && <GoogleSignInButton />}
+          </div>
+        )}
         {onMenuClick && (
           <button
             className="no-style dark:text-navy-100"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useRef } from "react"
 import cx from "classnames"
 import MenuIcon from "@meronex/icons/fi/FiMenu"
+import SupabaseConnector from "./SupabaseConnector"
+import { useStorage } from "../context/StorageContext"
 
 async function seedFromFile() {
   try {
@@ -64,6 +66,14 @@ function Header({
     }
   }, [])
 
+  const {
+    isSupabaseConnected,
+    syncStatus,
+    lastSyncedAt,
+    connectSupabase,
+    disconnectSupabase
+  } = useStorage()
+
   return (
     <header
       className={cx(
@@ -96,15 +106,24 @@ function Header({
           </time>
         )}
       </div>
-      {onMenuClick && (
-        <button
-          className="no-style dark:text-navy-100"
-          onClick={onMenuClick}
-          aria-label="Open menu"
-        >
-          <MenuIcon fontSize={22} />
-        </button>
-      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <SupabaseConnector
+          isConnected={isSupabaseConnected}
+          syncStatus={syncStatus}
+          lastSyncedAt={lastSyncedAt}
+          onConnect={connectSupabase}
+          onDisconnect={disconnectSupabase}
+        />
+        {onMenuClick && (
+          <button
+            className="no-style dark:text-navy-100"
+            onClick={onMenuClick}
+            aria-label="Open menu"
+          >
+            <MenuIcon fontSize={22} />
+          </button>
+        )}
+      </div>
     </header>
   )
 }

--- a/src/components/McpSetupSheet.tsx
+++ b/src/components/McpSetupSheet.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  apiToken: string | null
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="no-style text-[11px] font-medium text-slate-400 dark:text-navy-500 hover:text-slate-600 dark:hover:text-navy-300 transition-colors"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  )
+}
+
+function CodeBlock({ code }: { code: string }) {
+  return (
+    <div className="relative group mt-2">
+      <pre className="bg-slate-900 dark:bg-navy-950 text-slate-100 text-[12px] rounded-lg p-4 overflow-x-auto leading-relaxed">
+        {code}
+      </pre>
+      <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <CopyButton value={code} />
+      </div>
+    </div>
+  )
+}
+
+function McpSetupSheet({ open, onClose, apiToken }: Props) {
+  const config = JSON.stringify(
+    {
+      "what-todo": {
+        command: "npx",
+        args: ["-y", "what-todo-mcp"],
+        env: {
+          WHATTODO_API_TOKEN: apiToken ?? "<your-api-token>"
+        }
+      }
+    },
+    null,
+    2
+  )
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="mcp-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 bg-black/40 z-60"
+              onClick={onClose}
+              aria-hidden="true"
+            />
+            <motion.div
+              key="mcp-sheet"
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+              className="fixed bottom-0 left-0 right-0 z-60 bg-white dark:bg-navy-800 rounded-t-2xl shadow-xl"
+            >
+              <div className="flex justify-center pt-2 pb-1">
+                <div className="w-10 h-1 rounded-full bg-slate-300 dark:bg-navy-600" />
+              </div>
+              <div className="px-6 pb-10 pt-2 overflow-y-auto max-h-[85vh]">
+                <h2 className="text-base font-bold text-slate-700 dark:text-navy-100 mb-1">
+                  Use What Todo with Claude
+                </h2>
+                <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-6">
+                  Add What Todo as an MCP server so Claude Code can read and
+                  manage your tasks directly from the terminal.
+                </p>
+
+                <div className="mb-6">
+                  <h3 className="text-[13px] font-semibold text-slate-700 dark:text-navy-100 mb-1">
+                    1. Add to your Claude config
+                  </h3>
+                  <p className="text-[12px] text-slate-500 dark:text-navy-400 mb-1">
+                    In{" "}
+                    <code className="bg-slate-100 dark:bg-navy-700 px-1 py-0.5 rounded text-[11px]">
+                      ~/.claude.json
+                    </code>{" "}
+                    under{" "}
+                    <code className="bg-slate-100 dark:bg-navy-700 px-1 py-0.5 rounded text-[11px]">
+                      mcpServers
+                    </code>
+                    :
+                  </p>
+                  <CodeBlock code={config} />
+                </div>
+
+                <div className="mb-6">
+                  <h3 className="text-[13px] font-semibold text-slate-700 dark:text-navy-100 mb-1">
+                    2. Restart Claude Code
+                  </h3>
+                  <p className="text-[12px] text-slate-500 dark:text-navy-400">
+                    Run{" "}
+                    <code className="bg-slate-100 dark:bg-navy-700 px-1 py-0.5 rounded text-[11px]">
+                      /mcp
+                    </code>{" "}
+                    in Claude Code to verify the server is connected.
+                  </p>
+                </div>
+
+                <div className="mb-6">
+                  <h3 className="text-[13px] font-semibold text-slate-700 dark:text-navy-100 mb-2">
+                    3. Try it out
+                  </h3>
+                  <div className="flex flex-col gap-1.5">
+                    {[
+                      "What's on my todo list today?",
+                      "Add a task to review the pull request",
+                      "Mark the standup task as complete"
+                    ].map(example => (
+                      <div
+                        key={example}
+                        className="flex items-start gap-2 bg-slate-50 dark:bg-navy-700/50 rounded-lg px-3 py-2"
+                      >
+                        <span className="text-slate-300 dark:text-navy-600 text-[13px] mt-px select-none">
+                          "
+                        </span>
+                        <span className="text-[13px] text-slate-600 dark:text-navy-300 italic">
+                          {example}
+                        </span>
+                        <span className="text-slate-300 dark:text-navy-600 text-[13px] mt-px select-none">
+                          "
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {!apiToken && (
+                  <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2.5">
+                    <p className="text-[12px] text-amber-700 dark:text-amber-400">
+                      Sign in to get your personal API token. Your token
+                      identifies you to the MCP server and can be revoked at any
+                      time.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  )
+}
+
+export default McpSetupSheet

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -1,0 +1,243 @@
+import { useRef, useState } from "react"
+import cx from "classnames"
+import useOnClickOutside from "../hooks/onclickoutside"
+import SupabaseSetupGuide from "./SupabaseSetupGuide"
+import { SyncStatus } from "../adapters/DebouncedAdapter"
+
+interface Props {
+  isConnected: boolean
+  syncStatus: SyncStatus
+  lastSyncedAt: Date | null
+  onConnect: (url: string, anonKey: string) => Promise<void>
+  onDisconnect: () => void
+}
+
+function formatLastSynced(date: Date): string {
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+
+  if (diffSec < 5) return "Just now"
+  if (diffSec < 60) return `${diffSec}s ago`
+
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+
+  return date.toLocaleDateString()
+}
+
+function SyncIndicator({
+  syncStatus,
+  lastSyncedAt
+}: {
+  syncStatus: SyncStatus
+  lastSyncedAt: Date | null
+}) {
+  if (syncStatus === "syncing") {
+    return (
+      <span className="text-[11px] text-slate-400 dark:text-navy-500">
+        Syncing…
+      </span>
+    )
+  }
+
+  if (syncStatus === "error") {
+    return <span className="text-[11px] text-red-500">Sync failed</span>
+  }
+
+  if (lastSyncedAt) {
+    return (
+      <span className="text-[11px] text-slate-400 dark:text-navy-500">
+        {formatLastSynced(lastSyncedAt)}
+      </span>
+    )
+  }
+
+  return null
+}
+
+function SupabaseConnector({
+  isConnected,
+  syncStatus,
+  lastSyncedAt,
+  onConnect,
+  onDisconnect
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [url, setUrl] = useState("")
+  const [anonKey, setAnonKey] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [showSetup, setShowSetup] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(ref, () => setOpen(false))
+
+  const handleConnect = async () => {
+    if (!url.trim() || !anonKey.trim()) {
+      setError("Both fields are required")
+      return
+    }
+
+    setError(null)
+    setLoading(true)
+
+    try {
+      await onConnect(url.trim(), anonKey.trim())
+      setOpen(false)
+      setUrl("")
+      setAnonKey("")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Connection failed")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDisconnect = () => {
+    onDisconnect()
+    setOpen(false)
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      {isConnected ? (
+        <button
+          type="button"
+          className="flex items-center gap-2 bg-transparent border-none p-0 cursor-pointer text-inherit font-inherit"
+          onClick={() => setOpen(prev => !prev)}
+        >
+          <SyncIndicator syncStatus={syncStatus} lastSyncedAt={lastSyncedAt} />
+          <div className="flex items-center gap-1.5">
+            <span className="w-[7px] h-[7px] rounded-full bg-emerald-400 inline-block shrink-0" />
+            <span className="text-[13px] text-slate-500 dark:text-navy-400">
+              Connected
+            </span>
+          </div>
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="flex items-center gap-2 bg-transparent text-slate-500 dark:text-navy-400 border border-slate-200 dark:border-navy-600 rounded-lg px-3 py-1.5 text-[13px] font-medium cursor-pointer transition-all hover:border-emerald-400 hover:text-emerald-400"
+          onClick={() => setOpen(prev => !prev)}
+        >
+          Connect Supabase
+        </button>
+      )}
+
+      {open && (
+        <div className="absolute right-0 top-[calc(100%+8px)] w-[340px] bg-white dark:bg-navy-800 border border-slate-200 dark:border-navy-600 rounded-lg p-4 shadow-xl z-[100]">
+          {isConnected ? (
+            <div>
+              <div className="flex items-center gap-1.5 mb-3">
+                <span className="w-2 h-2 rounded-full bg-emerald-400 inline-block" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-navy-100">
+                  Connected to Supabase
+                </span>
+              </div>
+              <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-3">
+                Your data is being synced to your Supabase instance.
+              </p>
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                className="w-full px-3 py-2 text-[13px] font-semibold border border-slate-200 dark:border-navy-600 rounded-md bg-white dark:bg-navy-800 cursor-pointer text-red-500 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
+              >
+                Disconnect
+              </button>
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-semibold text-slate-700 dark:text-navy-100 mb-3">
+                Connect Supabase
+              </p>
+              <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-3">
+                Sync your data to your own Supabase instance. Your data stays
+                yours.
+              </p>
+
+              <p className="text-[11px] text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded px-2 py-1.5 mb-3 leading-snug">
+                🔒 Your project URL and anon key give full access to your data.
+                Never share them with anyone.
+              </p>
+
+              <div className="mb-2">
+                <label
+                  htmlFor="supabase-url"
+                  className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
+                >
+                  PROJECT URL
+                </label>
+                <input
+                  id="supabase-url"
+                  type="url"
+                  placeholder="https://xxxx.supabase.co"
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  autoComplete="off"
+                  className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
+                />
+              </div>
+
+              <div className="mb-3">
+                <label
+                  htmlFor="supabase-key"
+                  className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
+                >
+                  ANON KEY
+                </label>
+                <input
+                  id="supabase-key"
+                  type="password"
+                  placeholder="eyJhbGciOi..."
+                  value={anonKey}
+                  onChange={e => setAnonKey(e.target.value)}
+                  autoComplete="off"
+                  className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
+                />
+              </div>
+
+              {error && (
+                <p className="text-xs text-red-500 mb-2 leading-snug">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="button"
+                onClick={handleConnect}
+                disabled={loading}
+                className={cx(
+                  "w-full px-3 py-2 text-[13px] font-semibold border-none rounded-md text-white mb-3 transition-opacity",
+                  loading
+                    ? "opacity-60 cursor-wait"
+                    : "cursor-pointer hover:opacity-90"
+                )}
+                style={{ background: "#3ecf8e" }}
+              >
+                {loading ? "Connecting..." : "Connect"}
+              </button>
+
+              <button
+                type="button"
+                className="no-style text-xs text-slate-400 dark:text-navy-500 underline p-0"
+                onClick={() => setShowSetup(prev => !prev)}
+              >
+                {showSetup
+                  ? "Hide setup instructions"
+                  : "Need a Supabase instance?"}
+              </button>
+
+              {showSetup && <SupabaseSetupGuide />}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SupabaseConnector

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -1,15 +1,27 @@
-import { useRef, useState } from "react"
+import React, { useRef, useState } from "react"
 import cx from "classnames"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
 import useOnClickOutside from "../hooks/onclickoutside"
 import SupabaseSetupGuide from "./SupabaseSetupGuide"
+import { GoogleSignInButton } from "./GoogleSignInButton"
 import { SyncStatus } from "../adapters/DebouncedAdapter"
+
+export type OAuthProvider = "google"
 
 interface Props {
   isConnected: boolean
+  isAuthenticated: boolean
+  userEmail: string | null
   syncStatus: SyncStatus
   lastSyncedAt: Date | null
   onConnect: (url: string, anonKey: string) => Promise<void>
   onDisconnect: () => void
+  onSignIn: (provider: OAuthProvider) => Promise<void>
+  onSignOut: () => void
+  schemaOutdated?: boolean
+  externalOpen?: boolean
+  onExternalOpenChange?: (open: boolean) => void
 }
 
 function formatLastSynced(date: Date): string {
@@ -59,22 +71,253 @@ function SyncIndicator({
   return null
 }
 
+interface PanelProps {
+  isConnected: boolean
+  isAuthenticated: boolean
+  userEmail: string | null
+  url: string
+  anonKey: string
+  error: string | null
+  loading: boolean
+  showSetup: boolean
+  onUrlChange: (v: string) => void
+  onAnonKeyChange: (v: string) => void
+  onConnect: () => void
+  onDisconnect: () => void
+  onSignIn: (provider: OAuthProvider) => Promise<void>
+  onSignOut: () => void
+  onToggleSetup: () => void
+  schemaOutdated?: boolean
+}
+
+function ConnectorPanel({
+  isConnected,
+  isAuthenticated,
+  userEmail,
+  url,
+  anonKey,
+  error,
+  loading,
+  showSetup,
+  onUrlChange,
+  onAnonKeyChange,
+  onConnect,
+  onDisconnect,
+  onSignIn,
+  onSignOut,
+  onToggleSetup,
+  schemaOutdated
+}: PanelProps) {
+  // Step 3: connected + authenticated
+  if (isConnected && isAuthenticated) {
+    return (
+      <div>
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className="w-2 h-2 rounded-full bg-emerald-400 inline-block shrink-0" />
+          <span className="text-sm font-semibold text-slate-700 dark:text-navy-100">
+            Connected to Supabase
+          </span>
+        </div>
+        {userEmail && (
+          <p className="text-[12px] text-slate-400 dark:text-navy-500 mb-3 pl-3.5">
+            {userEmail}
+          </p>
+        )}
+        {schemaOutdated && (
+          <div className="mb-3 px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <p className="text-[12px] font-semibold text-amber-700 dark:text-amber-400 mb-0.5">
+              Database migration required
+            </p>
+            <p className="text-[11px] text-amber-600 dark:text-amber-500">
+              Your Supabase schema is out of date. Run the latest migration
+              script from the setup guide to continue syncing correctly.
+            </p>
+          </div>
+        )}
+        <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-4">
+          Your data is synced and secured with your account.
+        </p>
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onSignOut}
+            className="w-full px-3 py-2 text-[13px] font-semibold border border-slate-200 dark:border-navy-600 rounded-md bg-transparent cursor-pointer text-slate-600 dark:text-navy-300 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
+          >
+            Sign out
+          </button>
+          <button
+            type="button"
+            onClick={onDisconnect}
+            className="w-full px-3 py-2 text-[13px] font-semibold border border-slate-200 dark:border-navy-600 rounded-md bg-transparent cursor-pointer text-red-500 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
+          >
+            Disconnect
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Step 2: connected but not yet authenticated
+  if (isConnected && !isAuthenticated) {
+    return (
+      <div>
+        <p className="text-sm font-semibold text-slate-700 dark:text-navy-100 mb-1">
+          Sign in to your account
+        </p>
+        <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-4">
+          Sign in so your data is protected by your account, not just the anon
+          key.
+        </p>
+
+        <div className="flex flex-col gap-2 mb-4">
+          <GoogleSignInButton
+            onSignIn={() => onSignIn("google")}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-[13px] font-semibold border border-slate-200 dark:border-navy-600 rounded-md bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 cursor-pointer hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onDisconnect}
+          className="no-style text-xs text-slate-400 dark:text-navy-500 underline"
+        >
+          Disconnect
+        </button>
+      </div>
+    )
+  }
+
+  // Step 1: not connected
+  return (
+    <div>
+      <p className="text-sm font-semibold text-slate-700 dark:text-navy-100 mb-2">
+        Connect Supabase
+      </p>
+      <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-2">
+        By default, your data is stored in your browser and synced to What
+        Todo's servers when you're signed in.
+      </p>
+      <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-3">
+        Connecting your own Supabase project gives you full ownership of your
+        data — it never touches What Todo's servers. This also unlocks using the{" "}
+        <a
+          href="https://supabase.com/docs/guides/getting-started/mcp"
+          target="_blank"
+          rel="noreferrer"
+          className="underline text-slate-600 dark:text-navy-300 hover:text-slate-800 dark:hover:text-navy-100"
+        >
+          official Supabase MCP
+        </a>{" "}
+        as an alternative to What Todo's MCP server.
+      </p>
+
+      <div className="mb-2">
+        <label
+          htmlFor="supabase-url"
+          className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
+        >
+          PROJECT URL
+        </label>
+        <input
+          id="supabase-url"
+          type="url"
+          placeholder="https://xxxx.supabase.co"
+          value={url}
+          onChange={e => onUrlChange(e.target.value)}
+          autoComplete="off"
+          className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
+        />
+      </div>
+
+      <div className="mb-3">
+        <label
+          htmlFor="supabase-key"
+          className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
+        >
+          ANON KEY
+        </label>
+        <input
+          id="supabase-key"
+          type="password"
+          placeholder="eyJhbGciOi..."
+          value={anonKey}
+          onChange={e => onAnonKeyChange(e.target.value)}
+          autoComplete="off"
+          className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
+        />
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-500 mb-2 leading-snug">{error}</p>
+      )}
+
+      <button
+        type="button"
+        onClick={onConnect}
+        disabled={loading}
+        className={cx(
+          "w-full px-3 py-2 text-[13px] font-semibold border-none rounded-md text-white mb-3 transition-opacity",
+          loading ? "opacity-60 cursor-wait" : "cursor-pointer hover:opacity-90"
+        )}
+        style={{ background: "#3ecf8e" }}
+      >
+        {loading ? "Connecting..." : "Connect"}
+      </button>
+
+      <button
+        type="button"
+        className="no-style text-xs text-slate-500 dark:text-navy-300 underline p-0"
+        onClick={onToggleSetup}
+      >
+        {showSetup ? "Hide setup instructions" : "Need a Supabase project?"}
+      </button>
+
+      {showSetup && <SupabaseSetupGuide />}
+    </div>
+  )
+}
+
 function SupabaseConnector({
   isConnected,
+  isAuthenticated,
+  userEmail,
   syncStatus,
   lastSyncedAt,
   onConnect,
-  onDisconnect
+  onDisconnect,
+  onSignIn,
+  onSignOut,
+  schemaOutdated,
+  externalOpen,
+  onExternalOpenChange
 }: Props) {
-  const [open, setOpen] = useState(false)
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = externalOpen !== undefined ? externalOpen : internalOpen
+  const setOpen = (val: boolean) => {
+    setInternalOpen(val)
+    onExternalOpenChange?.(val)
+  }
   const [url, setUrl] = useState("")
   const [anonKey, setAnonKey] = useState("")
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showSetup, setShowSetup] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const [useSheet, setUseSheet] = useState(
+    () => !window.matchMedia("(min-width: 64em)").matches
+  )
 
-  useOnClickOutside(ref, () => setOpen(false))
+  React.useEffect(() => {
+    const mql = window.matchMedia("(min-width: 64em)")
+    const handler = (e: MediaQueryListEvent) => setUseSheet(!e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [])
+
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(popoverRef, () => {
+    if (!useSheet) setOpen(false)
+  })
 
   const handleConnect = async () => {
     if (!url.trim() || !anonKey.trim()) {
@@ -87,7 +330,6 @@ function SupabaseConnector({
 
     try {
       await onConnect(url.trim(), anonKey.trim())
-      setOpen(false)
       setUrl("")
       setAnonKey("")
     } catch (err) {
@@ -102,140 +344,114 @@ function SupabaseConnector({
     setOpen(false)
   }
 
+  const panelProps: PanelProps = {
+    isConnected,
+    isAuthenticated,
+    userEmail,
+    url,
+    anonKey,
+    error,
+    loading,
+    showSetup,
+    onUrlChange: setUrl,
+    onAnonKeyChange: setAnonKey,
+    onConnect: handleConnect,
+    onDisconnect: handleDisconnect,
+    onSignIn,
+    onSignOut,
+    onToggleSetup: () => setShowSetup(prev => !prev),
+    schemaOutdated
+  }
+
+  const isControlled = externalOpen !== undefined
+
+  const popoverAndSheet = (
+    <>
+      {/* Desktop popover */}
+      {!useSheet && open && (
+        <div
+          ref={popoverRef}
+          className="absolute right-0 top-[calc(100%+8px)] w-[340px] bg-white dark:bg-navy-800 border border-slate-200 dark:border-navy-600 rounded-lg p-4 shadow-xl z-[100]"
+        >
+          <ConnectorPanel {...panelProps} />
+        </div>
+      )}
+
+      {/* Mobile sheet */}
+      <Portal>
+        <AnimatePresence>
+          {useSheet && open && (
+            <>
+              <motion.div
+                key="supabase-backdrop"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 bg-black/40 z-60"
+                onClick={() => setOpen(false)}
+                aria-hidden="true"
+              />
+              <motion.div
+                key="supabase-sheet"
+                initial={{ y: "100%" }}
+                animate={{ y: 0 }}
+                exit={{ y: "100%" }}
+                transition={{ type: "spring", damping: 30, stiffness: 300 }}
+                className="fixed bottom-0 left-0 right-0 z-60 bg-white dark:bg-navy-800 rounded-t-2xl shadow-xl pb-safe"
+              >
+                <div className="flex justify-center pt-2 pb-1">
+                  <div className="w-10 h-1 rounded-full bg-slate-300 dark:bg-navy-600" />
+                </div>
+                <div className="px-8 pb-6 pt-2 overflow-y-auto max-h-[85vh]">
+                  <ConnectorPanel {...panelProps} />
+                </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      </Portal>
+    </>
+  )
+
+  if (isControlled) {
+    return popoverAndSheet
+  }
+
   return (
-    <div ref={ref} className="relative">
+    <div className="relative">
       {isConnected ? (
         <button
           type="button"
           className="flex items-center gap-2 bg-transparent border-none p-0 cursor-pointer text-inherit font-inherit"
-          onClick={() => setOpen(prev => !prev)}
+          onClick={() => setOpen(!open)}
         >
           <SyncIndicator syncStatus={syncStatus} lastSyncedAt={lastSyncedAt} />
           <div className="flex items-center gap-1.5">
             <span className="w-[7px] h-[7px] rounded-full bg-emerald-400 inline-block shrink-0" />
             <span className="text-[13px] text-slate-500 dark:text-navy-400">
-              Connected
+              {isAuthenticated ? "Syncing" : "Connect"}
             </span>
           </div>
         </button>
       ) : (
         <button
           type="button"
-          className="flex items-center gap-2 bg-transparent text-slate-500 dark:text-navy-400 border border-slate-200 dark:border-navy-600 rounded-lg px-3 py-1.5 text-[13px] font-medium cursor-pointer transition-all hover:border-emerald-400 hover:text-emerald-400"
-          onClick={() => setOpen(prev => !prev)}
+          className="flex items-center gap-2 bg-transparent text-slate-500 dark:text-navy-400 border border-slate-200 dark:border-navy-600 rounded-lg px-3 py-1.5 text-[13px] font-medium cursor-pointer transition-all"
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = "#3ecf8e"
+            e.currentTarget.style.color = "#3ecf8e"
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = ""
+            e.currentTarget.style.color = ""
+          }}
+          onClick={() => setOpen(!open)}
         >
           Connect Supabase
         </button>
       )}
 
-      {open && (
-        <div className="absolute right-0 top-[calc(100%+8px)] w-[340px] bg-white dark:bg-navy-800 border border-slate-200 dark:border-navy-600 rounded-lg p-4 shadow-xl z-[100]">
-          {isConnected ? (
-            <div>
-              <div className="flex items-center gap-1.5 mb-3">
-                <span className="w-2 h-2 rounded-full bg-emerald-400 inline-block" />
-                <span className="text-sm font-semibold text-slate-700 dark:text-navy-100">
-                  Connected to Supabase
-                </span>
-              </div>
-              <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-3">
-                Your data is being synced to your Supabase instance.
-              </p>
-              <button
-                type="button"
-                onClick={handleDisconnect}
-                className="w-full px-3 py-2 text-[13px] font-semibold border border-slate-200 dark:border-navy-600 rounded-md bg-white dark:bg-navy-800 cursor-pointer text-red-500 hover:bg-slate-50 dark:hover:bg-navy-700 transition-colors"
-              >
-                Disconnect
-              </button>
-            </div>
-          ) : (
-            <div>
-              <p className="text-sm font-semibold text-slate-700 dark:text-navy-100 mb-3">
-                Connect Supabase
-              </p>
-              <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-3">
-                Sync your data to your own Supabase instance. Your data stays
-                yours.
-              </p>
-
-              <p className="text-[11px] text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded px-2 py-1.5 mb-3 leading-snug">
-                🔒 Your project URL and anon key give full access to your data.
-                Never share them with anyone.
-              </p>
-
-              <div className="mb-2">
-                <label
-                  htmlFor="supabase-url"
-                  className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
-                >
-                  PROJECT URL
-                </label>
-                <input
-                  id="supabase-url"
-                  type="url"
-                  placeholder="https://xxxx.supabase.co"
-                  value={url}
-                  onChange={e => setUrl(e.target.value)}
-                  autoComplete="off"
-                  className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
-                />
-              </div>
-
-              <div className="mb-3">
-                <label
-                  htmlFor="supabase-key"
-                  className="block text-[11px] font-medium text-slate-500 dark:text-navy-400 mb-1"
-                >
-                  ANON KEY
-                </label>
-                <input
-                  id="supabase-key"
-                  type="password"
-                  placeholder="eyJhbGciOi..."
-                  value={anonKey}
-                  onChange={e => setAnonKey(e.target.value)}
-                  autoComplete="off"
-                  className="w-full p-2 border border-slate-200 dark:border-navy-600 rounded-md text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-emerald-400"
-                />
-              </div>
-
-              {error && (
-                <p className="text-xs text-red-500 mb-2 leading-snug">
-                  {error}
-                </p>
-              )}
-
-              <button
-                type="button"
-                onClick={handleConnect}
-                disabled={loading}
-                className={cx(
-                  "w-full px-3 py-2 text-[13px] font-semibold border-none rounded-md text-white mb-3 transition-opacity",
-                  loading
-                    ? "opacity-60 cursor-wait"
-                    : "cursor-pointer hover:opacity-90"
-                )}
-                style={{ background: "#3ecf8e" }}
-              >
-                {loading ? "Connecting..." : "Connect"}
-              </button>
-
-              <button
-                type="button"
-                className="no-style text-xs text-slate-400 dark:text-navy-500 underline p-0"
-                onClick={() => setShowSetup(prev => !prev)}
-              >
-                {showSetup
-                  ? "Hide setup instructions"
-                  : "Need a Supabase instance?"}
-              </button>
-
-              {showSetup && <SupabaseSetupGuide />}
-            </div>
-          )}
-        </div>
-      )}
+      {popoverAndSheet}
     </div>
   )
 }

--- a/src/components/SupabaseSetupGuide.tsx
+++ b/src/components/SupabaseSetupGuide.tsx
@@ -1,0 +1,76 @@
+const SQL_SNIPPET = `CREATE TABLE what_todo_data (
+  id TEXT PRIMARY KEY DEFAULT 'default',
+  data JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE what_todo_data ENABLE ROW LEVEL SECURITY;
+
+-- Allow full access via the anon key.
+-- This is safe because each user has their own Supabase project.
+-- The project URL + anon key act as the credentials — only someone
+-- who knows both can read or write the data.
+CREATE POLICY "Owner access" ON what_todo_data
+  FOR ALL USING (true) WITH CHECK (true);`
+
+const containerStyle: React.CSSProperties = {
+  marginTop: 8,
+  padding: 12,
+  background: "#f9f9f9",
+  borderRadius: 6,
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: "#555"
+}
+
+const listStyle: React.CSSProperties = { margin: 0, paddingLeft: 16 }
+
+const preStyle: React.CSSProperties = {
+  background: "#1e1e1e",
+  color: "#d4d4d4",
+  padding: 10,
+  borderRadius: 4,
+  fontSize: 11,
+  overflow: "auto",
+  margin: "8px 0",
+  whiteSpace: "pre-wrap"
+}
+
+function SupabaseSetupGuide() {
+  return (
+    <div style={containerStyle}>
+      <ol style={listStyle}>
+        <li>
+          Go to{" "}
+          <a
+            href="https://supabase.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#3ecf8e" }}
+          >
+            supabase.com
+          </a>{" "}
+          and create a free project.
+        </li>
+        <li>
+          Open the <strong>SQL Editor</strong> and run:
+        </li>
+      </ol>
+      <pre style={preStyle}>{SQL_SNIPPET}</pre>
+      <ol start={3} style={listStyle}>
+        <li>
+          Copy the <strong>Project URL</strong> and <strong>anon key</strong>{" "}
+          from <em>Settings → API</em>.
+        </li>
+        <li>Paste them above and click Connect.</li>
+      </ol>
+      <p style={{ fontSize: 11, color: "#888", margin: "8px 0 0" }}>
+        All your devices share the same data. Enter the same project URL and
+        anon key on each device to sync.
+      </p>
+    </div>
+  )
+}
+
+export default SupabaseSetupGuide

--- a/src/components/SupabaseSetupGuide.tsx
+++ b/src/components/SupabaseSetupGuide.tsx
@@ -1,5 +1,6 @@
 const SQL_SNIPPET = `CREATE TABLE what_todo_data (
   id TEXT PRIMARY KEY DEFAULT 'default',
+  user_id UUID NOT NULL DEFAULT auth.uid(),
   data JSONB NOT NULL DEFAULT '{}'::jsonb,
   updated_at TIMESTAMPTZ DEFAULT now()
 );
@@ -7,12 +8,9 @@ const SQL_SNIPPET = `CREATE TABLE what_todo_data (
 -- Enable Row Level Security
 ALTER TABLE what_todo_data ENABLE ROW LEVEL SECURITY;
 
--- Allow full access via the anon key.
--- This is safe because each user has their own Supabase project.
--- The project URL + anon key act as the credentials — only someone
--- who knows both can read or write the data.
+-- Only the authenticated owner can read or write their data
 CREATE POLICY "Owner access" ON what_todo_data
-  FOR ALL USING (true) WITH CHECK (true);`
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);`
 
 const containerStyle: React.CSSProperties = {
   marginTop: 8,
@@ -68,6 +66,10 @@ function SupabaseSetupGuide() {
       <p style={{ fontSize: 11, color: "#888", margin: "8px 0 0" }}>
         All your devices share the same data. Enter the same project URL and
         anon key on each device to sync.
+      </p>
+      <p style={{ fontSize: 11, color: "#888", margin: "6px 0 0" }}>
+        Occasionally, app updates may require running a short migration script
+        in your SQL editor. You'll see a warning in the app when this is needed.
       </p>
     </div>
   )

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -249,7 +249,7 @@ const Task: React.FC<Props> = ({
         onMouseLeave={() => setHovering(false)}
         onAnimationEnd={() => setGlowing(false)}
       >
-        <div className="mt-[2px] mr-3">
+        <div className="mt-[2px] mr-3 shrink-0">
           <Checkbox
             id={task.id}
             checked={state?.completed ?? false}
@@ -257,236 +257,240 @@ const Task: React.FC<Props> = ({
           />
         </div>
 
-        <div className="flex-1 overflow-hidden">
-          {active ? (
-            <Textarea
-              maxRows={3}
-              value={state?.title}
-              spellCheck={active}
-              className={cx(
-                "unstyled task-title-input font-semibold text-slate-700 dark:text-navy-100 leading-normal bg-transparent pt-0",
-                {
-                  ["text-slate-400 dark:text-navy-400"]: state?.completed
-                }
-              )}
-              onKeyDown={handleKeyDown}
-              onChange={handleChange("title")}
-              onFocus={selectTask}
-              onBlur={handleBlur}
-            />
-          ) : (
-            <div
-              className={cx(
-                "inline font-semibold text-slate-700 dark:text-navy-100",
-                {
-                  ["text-slate-400 dark:text-navy-400"]: state?.completed
-                }
-              )}
-            >
-              {state?.completed
-                ? state?.title
-                    .split(/\s/)
-                    .filter(Boolean)
-                    .map((word, i) => (
-                      <span
-                        key={word}
-                        className="strike-animated inline-flex mr-1"
-                        style={{ "--strike-index": i } as React.CSSProperties}
-                      >
-                        {word}
-                      </span>
-                    ))
-                : state?.title}
-            </div>
-          )}
-
-          <>
-            {(state?.description || active) && (
-              <div className="mt-1">
+        <div className="flex-1 overflow-hidden min-w-0">
+          <div className="flex items-start">
+            <div className="flex-1 overflow-hidden min-w-0">
+              {active ? (
                 <Textarea
-                  maxRows={10}
-                  name="description"
-                  value={getDescription(active, state?.description)}
-                  placeholder={active ? "Add description..." : ""}
-                  className="unstyled text-slate-500 dark:text-navy-400 text-sm bg-transparent max-h-[800px]"
-                  onChange={handleChange("description")}
+                  maxRows={3}
+                  value={state?.title}
+                  spellCheck={active}
+                  className={cx(
+                    "unstyled task-title-input font-semibold text-slate-700 dark:text-navy-100 leading-normal bg-transparent pt-0",
+                    {
+                      ["text-slate-400 dark:text-navy-400"]: state?.completed
+                    }
+                  )}
                   onKeyDown={handleKeyDown}
+                  onChange={handleChange("title")}
                   onFocus={selectTask}
                   onBlur={handleBlur}
                 />
-              </div>
-            )}
-
-            <Animate active={active}>
-              <div className="flex mt-2 flex-wrap">
-                {Object.entries(labels).map(([id, label]) => (
-                  <div className="mr-1 mb-1" key={id}>
-                    <Label
-                      small
-                      active={state?.labels?.includes(id) ?? false}
-                      label={label}
-                      onClick={preventDefault(() => {
-                        if (!state) return
-                        const currentLabels = state.labels ?? []
-                        const nextLabels = currentLabels.includes(id)
-                          ? currentLabels.filter(l => l !== id)
-                          : [...currentLabels, id]
-                        const updated = { ...state, labels: nextLabels }
-                        setState(updated)
-                        onUpdate(updated)
-                      })}
-                    />
-                  </div>
-                ))}
-              </div>
-            </Animate>
-          </>
-        </div>
-
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
-        <div
-          aria-label="Task actions"
-          role="group"
-          className="flex items-center ml-auto shrink-0"
-          onClick={e => e.stopPropagation()}
-        >
-          {onMoveToToday && (
-            <button
-              type="button"
-              data-tooltip-id="tooltip"
-              data-tooltip-content="Move to today (M)"
-              aria-label="Move to today"
-              className="no-style remove-icon touch-target"
-              onClick={preventDefault(() => {
-                onMoveToToday(state ?? task)
-              })}
-            >
-              <RightArrowIcon fontSize={20} />
-            </button>
-          )}
-
-          {canPin && !state?.completed && (
-            <button
-              type="button"
-              data-tooltip-id="tooltip"
-              data-tooltip-content={
-                state?.pinned ? "Unpin task (P)" : "Pin task (P)"
-              }
-              aria-label={state?.pinned ? "Unpin task" : "Pin task"}
-              className={cx("no-style remove-icon touch-target", {
-                active: state?.pinned
-              })}
-              style={state?.pinned ? { color: "#93c5fd" } : undefined}
-              onClick={preventDefault(() => {
-                if (!state) return
-                haptic()
-                const pinning = !Boolean(state.pinned)
-                const updated = { ...state, pinned: pinning }
-                setState(updated)
-                onUpdate(updated)
-                if (pinning) setGlowing(true)
-                onDeselect()
-              })}
-            >
-              {state?.pinned ? (
-                <PinFilled fontSize={20} />
               ) : (
-                <Pin fontSize={20} />
-              )}
-            </button>
-          )}
-
-          {descriptionURL && (
-            <button
-              type="button"
-              data-tooltip-id="tooltip"
-              data-tooltip-content={shortenURL(descriptionURL)}
-              aria-label="Open link"
-              className={cx("no-style remove-icon touch-target", {
-                active: true
-              })}
-              onClick={preventDefault(() => {
-                window.open(descriptionURL, "_blank")
-              })}
-            >
-              <FiLink fontSize={20} />
-            </button>
-          )}
-
-          {!active &&
-            (state?.labels ?? task.labels)
-              ?.sort((a, b) => a.localeCompare(b))
-              ?.map(id => {
-                const handleLabelClick = preventDefault(
-                  (event: MouseEvent<any>) => {
-                    if (filters.includes(id)) {
-                      onFilter(filters.filter(f => f !== id))
-                    } else {
-                      if (event.metaKey) {
-                        onFilter([...filters, id])
-                      } else {
-                        onFilter([id])
-                      }
+                <div
+                  className={cx(
+                    "inline font-semibold text-slate-700 dark:text-navy-100",
+                    {
+                      ["text-slate-400 dark:text-navy-400"]: state?.completed
                     }
+                  )}
+                >
+                  {state?.completed
+                    ? state?.title
+                        .split(/\s/)
+                        .filter(Boolean)
+                        .map((word, i) => (
+                          <span
+                            key={word}
+                            className="strike-animated inline-flex mr-1"
+                            style={
+                              { "--strike-index": i } as React.CSSProperties
+                            }
+                          >
+                            {word}
+                          </span>
+                        ))
+                    : state?.title}
+                </div>
+              )}
+            </div>
+
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
+            <div
+              aria-label="Task actions"
+              role="group"
+              className="flex items-center ml-auto shrink-0"
+              onClick={e => e.stopPropagation()}
+            >
+              {onMoveToToday && (
+                <button
+                  type="button"
+                  data-tooltip-id="tooltip"
+                  data-tooltip-content="Move to today (M)"
+                  aria-label="Move to today"
+                  className="no-style remove-icon touch-target"
+                  onClick={preventDefault(() => {
+                    onMoveToToday(state ?? task)
+                  })}
+                >
+                  <RightArrowIcon fontSize={20} />
+                </button>
+              )}
+
+              {canPin && !state?.completed && (
+                <button
+                  type="button"
+                  data-tooltip-id="tooltip"
+                  data-tooltip-content={
+                    state?.pinned ? "Unpin task (P)" : "Pin task (P)"
                   }
-                )
+                  aria-label={state?.pinned ? "Unpin task" : "Pin task"}
+                  className={cx("no-style remove-icon touch-target", {
+                    active: state?.pinned
+                  })}
+                  style={state?.pinned ? { color: "#93c5fd" } : undefined}
+                  onClick={preventDefault(() => {
+                    if (!state) return
+                    haptic()
+                    const pinning = !Boolean(state.pinned)
+                    const updated = { ...state, pinned: pinning }
+                    setState(updated)
+                    onUpdate(updated)
+                    if (pinning) setGlowing(true)
+                    onDeselect()
+                  })}
+                >
+                  {state?.pinned ? (
+                    <PinFilled fontSize={20} />
+                  ) : (
+                    <Pin fontSize={20} />
+                  )}
+                </button>
+              )}
 
-                if (settings.labelStyle === "pill") {
-                  const bg = labels[id]?.color
-                  return (
-                    <span
-                      key={id}
-                      role="button"
-                      tabIndex={0}
-                      className="inline-flex items-center text-[10px] font-bold rounded-full px-2 py-0.5 ml-1 cursor-pointer"
-                      style={{
-                        backgroundColor: bg,
-                        color: bg ? contrastText(bg) : undefined
-                      }}
-                      onClick={handleLabelClick}
-                      onKeyDown={e => {
-                        if (e.key === "Enter" || e.key === " ")
-                          handleLabelClick(e as any)
-                      }}
-                    >
-                      {labels[id]?.title}
-                    </span>
-                  )
-                }
+              {descriptionURL && (
+                <button
+                  type="button"
+                  data-tooltip-id="tooltip"
+                  data-tooltip-content={shortenURL(descriptionURL)}
+                  aria-label="Open link"
+                  className={cx("no-style remove-icon touch-target", {
+                    active: true
+                  })}
+                  onClick={preventDefault(() => {
+                    window.open(descriptionURL, "_blank")
+                  })}
+                >
+                  <FiLink fontSize={20} />
+                </button>
+              )}
 
-                return (
-                  <span
-                    key={id}
-                    role="button"
-                    tabIndex={0}
-                    className="w-[20px] h-[20px] rounded-full p-0 ml-2 grow-0 shrink-0 cursor-pointer"
-                    data-tooltip-id="tooltip"
-                    data-tooltip-content={labels[id]?.title}
-                    aria-label={labels[id]?.title}
-                    style={{ backgroundColor: labels[id]?.color }}
-                    onClick={handleLabelClick}
-                    onKeyDown={e => {
-                      if (e.key === "Enter" || e.key === " ")
-                        handleLabelClick(e as any)
-                    }}
+              {!active &&
+                (state?.labels ?? task.labels)
+                  ?.sort((a, b) => a.localeCompare(b))
+                  ?.map(id => {
+                    const handleLabelClick = preventDefault(
+                      (event: MouseEvent<any>) => {
+                        if (filters.includes(id)) {
+                          onFilter(filters.filter(f => f !== id))
+                        } else {
+                          if (event.metaKey) {
+                            onFilter([...filters, id])
+                          } else {
+                            onFilter([id])
+                          }
+                        }
+                      }
+                    )
+
+                    if (settings.labelStyle === "pill") {
+                      const bg = labels[id]?.color
+                      return (
+                        <span
+                          key={id}
+                          role="button"
+                          tabIndex={0}
+                          className="inline-flex items-center text-[10px] font-bold rounded-full px-2 py-0.5 ml-1 cursor-pointer"
+                          style={{
+                            backgroundColor: bg,
+                            color: bg ? contrastText(bg) : undefined
+                          }}
+                          onClick={handleLabelClick}
+                          onKeyDown={e => {
+                            if (e.key === "Enter" || e.key === " ")
+                              handleLabelClick(e as any)
+                          }}
+                        >
+                          {labels[id]?.title}
+                        </span>
+                      )
+                    }
+
+                    return (
+                      <span
+                        key={id}
+                        role="button"
+                        tabIndex={0}
+                        className="w-[20px] h-[20px] rounded-full p-0 ml-2 grow-0 shrink-0 cursor-pointer"
+                        data-tooltip-id="tooltip"
+                        data-tooltip-content={labels[id]?.title}
+                        aria-label={labels[id]?.title}
+                        style={{ backgroundColor: labels[id]?.color }}
+                        onClick={handleLabelClick}
+                        onKeyDown={e => {
+                          if (e.key === "Enter" || e.key === " ")
+                            handleLabelClick(e as any)
+                        }}
+                      />
+                    )
+                  })}
+
+              <button
+                type="button"
+                className="no-style remove-icon touch-target overflow-hidden transition-all duration-200 max-w-[44px] opacity-100 md:max-w-0 md:opacity-0 group-hover:max-w-[44px] group-hover:opacity-100"
+                data-tooltip-id="tooltip"
+                data-tooltip-content="Delete (X)"
+                aria-label="Delete task"
+                onPointerUp={e => {
+                  e.stopPropagation()
+                  haptic()
+                  onRemoveTask(state ?? task)
+                }}
+              >
+                <CrossIcon fontSize={20} />
+              </button>
+            </div>
+          </div>
+
+          {(state?.description || active) && (
+            <div className="mt-1">
+              <Textarea
+                maxRows={10}
+                name="description"
+                value={getDescription(active, state?.description)}
+                placeholder={active ? "Add description..." : ""}
+                className="unstyled text-slate-500 dark:text-navy-400 text-sm bg-transparent max-h-[800px] w-full"
+                onChange={handleChange("description")}
+                onKeyDown={handleKeyDown}
+                onFocus={selectTask}
+                onBlur={handleBlur}
+              />
+            </div>
+          )}
+
+          <Animate active={active}>
+            <div className="flex mt-2 flex-wrap">
+              {Object.entries(labels).map(([id, label]) => (
+                <div className="mr-1 mb-1" key={id}>
+                  <Label
+                    small
+                    active={state?.labels?.includes(id) ?? false}
+                    label={label}
+                    onClick={preventDefault(() => {
+                      if (!state) return
+                      const currentLabels = state.labels ?? []
+                      const nextLabels = currentLabels.includes(id)
+                        ? currentLabels.filter(l => l !== id)
+                        : [...currentLabels, id]
+                      const updated = { ...state, labels: nextLabels }
+                      setState(updated)
+                      onUpdate(updated)
+                    })}
                   />
-                )
-              })}
-
-          <button
-            type="button"
-            className="no-style remove-icon touch-target overflow-hidden transition-all duration-200 max-w-[44px] opacity-100 md:max-w-0 md:opacity-0 group-hover:max-w-[44px] group-hover:opacity-100"
-            data-tooltip-id="tooltip"
-            data-tooltip-content="Delete (X)"
-            aria-label="Delete task"
-            onPointerUp={e => {
-              e.stopPropagation()
-              haptic()
-              onRemoveTask(state ?? task)
-            }}
-          >
-            <CrossIcon fontSize={20} />
-          </button>
+                </div>
+              ))}
+            </div>
+          </Animate>
         </div>
       </div>
     </Animate>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -21,6 +21,8 @@ import Label from "./Label"
 import ToggleButton from "./ToggleButton"
 import Header from "./Header"
 import MobileDrawer from "./MobileDrawer"
+import McpSetupSheet from "./McpSetupSheet"
+import { useAuth } from "../context/AuthContext"
 import Settings from "./Settings"
 import { useSettings } from "../context/SettingsContext"
 import useResize from "../hooks/useResize"
@@ -206,7 +208,9 @@ const Todo: React.FC = ({}) => {
   }, [])
 
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [mcpOpen, setMcpOpen] = useState(false)
   const [labelsCollapsed, setLabelsCollapsed] = useState(false)
+  const { user } = useAuth()
 
   const [mounted, setMounted] = useState(false)
   React.useEffect(() => {
@@ -626,7 +630,21 @@ const Todo: React.FC = ({}) => {
               </span>
             </button>
           }
-          footer={<Footer />}
+          footer={
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setDrawerOpen(false)
+                  setMcpOpen(true)
+                }}
+                className="no-style w-full text-left text-[13px] font-medium text-slate-400 dark:text-navy-500 hover:text-slate-600 dark:hover:text-navy-300 transition-colors py-1"
+              >
+                /mcp — Use with Claude
+              </button>
+              <Footer />
+            </div>
+          }
         >
           <div className="flex-1 overflow-y-auto pb-2">
             <Collapse open={!labelsCollapsed}>
@@ -648,6 +666,12 @@ const Todo: React.FC = ({}) => {
           </div>
         </MobileDrawer>
       )}
+
+      <McpSetupSheet
+        open={mcpOpen}
+        onClose={() => setMcpOpen(false)}
+        apiToken={user?.id ?? null}
+      />
 
       {pendingDelete && (
         <Toast

--- a/src/components/WaitlistSheet.tsx
+++ b/src/components/WaitlistSheet.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
+import { supabase } from "../lib/supabase"
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+type Status = "idle" | "loading" | "success" | "error"
+
+function WaitlistSheet({ open, onClose }: Props) {
+  const [email, setEmail] = useState("")
+  const [status, setStatus] = useState<Status>("idle")
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const isValidEmail = (value: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!supabase) return
+
+    if (!isValidEmail(email)) {
+      setErrorMsg("Please enter a valid email address.")
+      return
+    }
+
+    setStatus("loading")
+    setErrorMsg(null)
+
+    const { error } = await supabase
+      .from("waitlist")
+      .insert({ email: email.trim().toLowerCase() })
+
+    if (error) {
+      if (error.code === "23505") {
+        // Already on the list — treat as success
+        setStatus("success")
+      } else {
+        setStatus("error")
+        setErrorMsg("Something went wrong. Please try again.")
+      }
+    } else {
+      setStatus("success")
+    }
+  }
+
+  const handleClose = () => {
+    setEmail("")
+    setStatus("idle")
+    setErrorMsg(null)
+    onClose()
+  }
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="waitlist-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 bg-black/40 z-60"
+              onClick={handleClose}
+              aria-hidden="true"
+            />
+            <motion.div
+              key="waitlist-sheet"
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+              className="fixed bottom-0 left-0 right-0 z-60 bg-white dark:bg-navy-800 rounded-t-2xl shadow-xl"
+            >
+              <div className="flex justify-center pt-2 pb-1">
+                <div className="w-10 h-1 rounded-full bg-slate-300 dark:bg-navy-600" />
+              </div>
+
+              <div className="px-6 pb-10 pt-3">
+                {status === "success" ? (
+                  <div className="text-center py-4">
+                    <p className="text-2xl mb-3">🎉</p>
+                    <h2 className="text-base font-bold text-slate-700 dark:text-navy-100 mb-2">
+                      You're on the list
+                    </h2>
+                    <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-6">
+                      We'll email you when your account is ready.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleClose}
+                      className="no-style text-[13px] font-medium text-slate-500 dark:text-navy-400 underline"
+                    >
+                      Close
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <h2 className="text-base font-bold text-slate-700 dark:text-navy-100 mb-2">
+                      Early access only
+                    </h2>
+                    <p className="text-[13px] text-slate-500 dark:text-navy-400 mb-5">
+                      Sign-in is currently invite-only while we roll out
+                      gradually. Leave your email and we'll let you know when
+                      your spot is ready.
+                    </p>
+
+                    <form
+                      onSubmit={handleSubmit}
+                      className="flex flex-col gap-3"
+                    >
+                      <input
+                        type="email"
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={e => setEmail(e.target.value)}
+                        required
+                        className="w-full p-3 border border-slate-200 dark:border-navy-600 rounded-xl text-[13px] bg-white dark:bg-navy-900 text-slate-700 dark:text-navy-100 placeholder:text-slate-400 dark:placeholder:text-navy-500 outline-none focus:border-blue-400"
+                      />
+
+                      {errorMsg && (
+                        <p className="text-xs text-red-500">{errorMsg}</p>
+                      )}
+
+                      <button
+                        type="submit"
+                        disabled={status === "loading" || !email.trim()}
+                        className="w-full py-3 rounded-xl text-[13px] font-semibold text-white bg-slate-800 dark:bg-navy-600 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer hover:opacity-90 transition-opacity"
+                      >
+                        {status === "loading" ? "Joining…" : "Request access"}
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={handleClose}
+                        className="no-style text-[12px] text-slate-500 dark:text-navy-300 text-center"
+                      >
+                        Maybe later
+                      </button>
+                    </form>
+                  </>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  )
+}
+
+export default WaitlistSheet

--- a/src/components/__tests__/DataConflictSheet.test.tsx
+++ b/src/components/__tests__/DataConflictSheet.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import DataConflictSheet from "../DataConflictSheet"
+import { Data } from "../../index.d"
+
+const makeData = (taskTitles: string[] = []): Data => ({
+  filters: [],
+  tasks: taskTitles.length
+    ? {
+        "Wed Jan 01 2025": taskTitles.map((title, i) => ({
+          id: `task-${i}`,
+          title,
+          completed: false,
+          created_at: new Date("2025-01-01").toISOString(),
+          labels: []
+        }))
+      }
+    : {},
+  labels: [],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+})
+
+const onUseRemote = vi.fn()
+const onMerge = vi.fn()
+
+describe("DataConflictSheet", () => {
+  beforeEach(() => {
+    onUseRemote.mockClear()
+    onMerge.mockClear()
+    if (!document.getElementById("portal")) {
+      const el = document.createElement("div")
+      el.id = "portal"
+      document.body.appendChild(el)
+    }
+  })
+
+  it("does not render when closed", () => {
+    render(
+      <DataConflictSheet
+        open={false}
+        local={null}
+        remote={null}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    expect(screen.queryByText(/todos on this device/)).toBeNull()
+  })
+
+  it("renders task counts from both sides", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["Task A", "Task B"])}
+        remote={makeData(["Task C"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    expect(screen.getByText(/2 local task/)).toBeDefined()
+    expect(screen.getAllByText(/1 cloud task/).length).toBeGreaterThan(0)
+  })
+
+  it("confirm button is disabled until a choice is made", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["A"])}
+        remote={makeData(["B"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    const btn = screen.getByRole("button", { name: /Select an option/i })
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("enables confirm and shows merge label after selecting merge", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["A"])}
+        remote={makeData(["B"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    fireEvent.click(screen.getByText("Merge both"))
+    const btn = screen.getByRole("button", { name: /Merge 2 tasks/i })
+    expect((btn as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it("shows warning when 'use cloud' is selected", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["A", "B"])}
+        remote={makeData(["C"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    fireEvent.click(screen.getByText("Use cloud data"))
+    expect(screen.getByText(/discard your 2 local task/)).toBeDefined()
+  })
+
+  it("calls onMerge when merge is confirmed", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["A"])}
+        remote={makeData(["B"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    fireEvent.click(screen.getByText("Merge both"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge 2 tasks/i }))
+    expect(onMerge).toHaveBeenCalled()
+    expect(onUseRemote).not.toHaveBeenCalled()
+  })
+
+  it("calls onUseRemote when use cloud is confirmed", () => {
+    render(
+      <DataConflictSheet
+        open={true}
+        local={makeData(["A"])}
+        remote={makeData(["B"])}
+        onUseRemote={onUseRemote}
+        onMerge={onMerge}
+      />
+    )
+    fireEvent.click(screen.getByText("Use cloud data"))
+    fireEvent.click(screen.getByRole("button", { name: /Use 1 cloud task/i }))
+    expect(onUseRemote).toHaveBeenCalled()
+    expect(onMerge).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/WaitlistSheet.test.tsx
+++ b/src/components/__tests__/WaitlistSheet.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import WaitlistSheet from "../WaitlistSheet"
+
+// Mock the supabase client
+let insertResult: { error: { code?: string; message: string } | null } = {
+  error: null
+}
+
+vi.mock("../../lib/supabase", () => ({
+  supabase: {
+    from: () => ({
+      insert: async () => insertResult
+    })
+  }
+}))
+
+// Portal renders into document.body — no extra setup needed with happy-dom
+
+const onClose = vi.fn()
+
+describe("WaitlistSheet", () => {
+  beforeEach(() => {
+    insertResult = { error: null }
+    onClose.mockClear()
+    // Portal renders into #portal — create it if missing
+    if (!document.getElementById("portal")) {
+      const el = document.createElement("div")
+      el.id = "portal"
+      document.body.appendChild(el)
+    }
+  })
+
+  it("does not render when closed", () => {
+    render(<WaitlistSheet open={false} onClose={onClose} />)
+    expect(screen.queryByText("Early access only")).toBeNull()
+  })
+
+  it("renders the form when open", () => {
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    expect(screen.getByText("Early access only")).toBeDefined()
+    expect(screen.getByPlaceholderText("you@example.com")).toBeDefined()
+    expect(screen.getByText("Request access")).toBeDefined()
+  })
+
+  it("shows validation error for invalid email", async () => {
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    const input = screen.getByPlaceholderText("you@example.com")
+    fireEvent.change(input, { target: { value: "notanemail" } })
+    fireEvent.submit(input.closest("form")!)
+    await waitFor(() => {
+      expect(
+        screen.getByText("Please enter a valid email address.")
+      ).toBeDefined()
+    })
+  })
+
+  it("shows success state after valid submission", async () => {
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "test@example.com" }
+    })
+    fireEvent.click(screen.getByText("Request access"))
+    await waitFor(() => {
+      expect(screen.getByText("You're on the list")).toBeDefined()
+    })
+  })
+
+  it("treats duplicate email as success", async () => {
+    insertResult = { error: { code: "23505", message: "duplicate key" } }
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "existing@example.com" }
+    })
+    fireEvent.click(screen.getByText("Request access"))
+    await waitFor(() => {
+      expect(screen.getByText("You're on the list")).toBeDefined()
+    })
+  })
+
+  it("shows error message on unexpected failure", async () => {
+    insertResult = { error: { message: "network error" } }
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "test@example.com" }
+    })
+    fireEvent.click(screen.getByText("Request access"))
+    await waitFor(() => {
+      expect(
+        screen.getByText("Something went wrong. Please try again.")
+      ).toBeDefined()
+    })
+  })
+
+  it("calls onClose when backdrop is clicked", () => {
+    render(<WaitlistSheet open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText("Maybe later"))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from "react"
 import type { User } from "@supabase/supabase-js"
 import { supabase } from "../lib/supabase"
 import Toast from "../components/Toast"
+import WaitlistSheet from "../components/WaitlistSheet"
 
 export type OAuthProvider = "google"
 
@@ -21,24 +22,34 @@ const AuthContext = createContext<AuthContextValue>({
   signOut: () => Promise.resolve()
 })
 
-function parseOAuthError(): string | null {
-  const params = new URLSearchParams(window.location.search)
-  const description = params.get("error_description")
-  if (!description) return null
+interface OAuthError {
+  code: string | null
+  description: string | null
+}
 
-  // Clean the error params from the URL without triggering a navigation
+function parseOAuthError(): OAuthError | null {
+  const params = new URLSearchParams(window.location.search)
+  const code = params.get("error_code")
+  const description = params.get("error_description")
+  if (!code && !description) return null
+
   const clean = new URL(window.location.href)
   clean.searchParams.delete("error")
   clean.searchParams.delete("error_code")
   clean.searchParams.delete("error_description")
   window.history.replaceState(null, "", clean.toString())
 
-  return decodeURIComponent(description.replace(/\+/g, " "))
+  return {
+    code,
+    description: description
+      ? decodeURIComponent(description.replace(/\+/g, " "))
+      : null
+  }
 }
 
 export function AuthProvider({ children }: React.PropsWithChildren<unknown>) {
   const [user, setUser] = useState<User | null>(null)
-  const [authError, setAuthError] = useState<string | null>(() =>
+  const [authError, setAuthError] = useState<OAuthError | null>(() =>
     parseOAuthError()
   )
 
@@ -71,6 +82,8 @@ export function AuthProvider({ children }: React.PropsWithChildren<unknown>) {
     await supabase.auth.signOut()
   }
 
+  const isWaitlistError = authError?.code === "signup_disabled"
+
   return (
     <AuthContext.Provider
       value={{
@@ -82,9 +95,18 @@ export function AuthProvider({ children }: React.PropsWithChildren<unknown>) {
       }}
     >
       {children}
-      {authError && (
-        <Toast message={authError} onDismiss={() => setAuthError(null)} />
+
+      {authError && !isWaitlistError && (
+        <Toast
+          message={authError.description ?? "Sign in failed"}
+          onDismiss={() => setAuthError(null)}
+        />
       )}
+
+      <WaitlistSheet
+        open={isWaitlistError}
+        onClose={() => setAuthError(null)}
+      />
     </AuthContext.Provider>
   )
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,94 @@
+import React, { createContext, useContext, useEffect, useState } from "react"
+import type { User } from "@supabase/supabase-js"
+import { supabase } from "../lib/supabase"
+import Toast from "../components/Toast"
+
+export type OAuthProvider = "google"
+
+interface AuthContextValue {
+  user: User | null
+  isAuthenticated: boolean
+  supabaseConfigured: boolean
+  signIn: (provider: OAuthProvider) => Promise<void>
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isAuthenticated: false,
+  supabaseConfigured: false,
+  signIn: () => Promise.resolve(),
+  signOut: () => Promise.resolve()
+})
+
+function parseOAuthError(): string | null {
+  const params = new URLSearchParams(window.location.search)
+  const description = params.get("error_description")
+  if (!description) return null
+
+  // Clean the error params from the URL without triggering a navigation
+  const clean = new URL(window.location.href)
+  clean.searchParams.delete("error")
+  clean.searchParams.delete("error_code")
+  clean.searchParams.delete("error_description")
+  window.history.replaceState(null, "", clean.toString())
+
+  return decodeURIComponent(description.replace(/\+/g, " "))
+}
+
+export function AuthProvider({ children }: React.PropsWithChildren<unknown>) {
+  const [user, setUser] = useState<User | null>(null)
+  const [authError, setAuthError] = useState<string | null>(() =>
+    parseOAuthError()
+  )
+
+  useEffect(() => {
+    if (!supabase) return
+
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null)
+    })
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setUser(session?.user ?? null)
+      }
+    )
+
+    return () => listener.subscription.unsubscribe()
+  }, [])
+
+  const signIn = async (provider: OAuthProvider) => {
+    if (!supabase) return
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: window.location.origin }
+    })
+  }
+
+  const signOut = async () => {
+    if (!supabase) return
+    await supabase.auth.signOut()
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !!user,
+        supabaseConfigured: !!supabase,
+        signIn,
+        signOut
+      }}
+    >
+      {children}
+      {authError && (
+        <Toast message={authError} onDismiss={() => setAuthError(null)} />
+      )}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  return useContext(AuthContext)
+}

--- a/src/context/StorageContext.tsx
+++ b/src/context/StorageContext.tsx
@@ -1,14 +1,37 @@
 import { Data, Filters, Label, Section, SectionData, Task } from "../index.d"
-import React, { PropsWithChildren, useCallback } from "react"
+import React, { PropsWithChildren, useCallback, useRef, useState } from "react"
 
 import StorageManager from "../StorageManager"
+import { StorageAdapter } from "../adapters/StorageAdapter"
+import { LocalStorageAdapter } from "../adapters/LocalStorageAdapter"
+import { SupabaseStorageAdapter } from "../adapters/SupabaseStorageAdapter"
+import { DebouncedAdapter, SyncStatus } from "../adapters/DebouncedAdapter"
+import { migrateData } from "../adapters/migrateData"
+import {
+  getSupabaseConfig,
+  setSupabaseConfig,
+  clearSupabaseConfig
+} from "../adapters/supabaseConfig"
 
-const storage = new StorageManager()
+function createInitialAdapter(): StorageAdapter {
+  const config = getSupabaseConfig()
+  if (config) {
+    try {
+      return new DebouncedAdapter(
+        new SupabaseStorageAdapter(config.url, config.anonKey)
+      )
+    } catch {
+      // Invalid stored config — fall back to localStorage
+      clearSupabaseConfig()
+    }
+  }
+  return new LocalStorageAdapter()
+}
 
 interface Storage {
   data: Data
   labelsById: Record<string, Label>
-  storage: typeof storage
+  storage: StorageManager
   sections?: Record<Section, SectionData>
   fetchData: () => void
   addTask: (task: Task) => void
@@ -22,16 +45,23 @@ interface Storage {
   updateFilters: (filters: Filters) => void
   updateSection: (key: Section, data: SectionData) => void
   updateSections: (updates: Record<string, SectionData>) => void
-  uploadData: typeof storage.uploadData
+  uploadData: (data: Data) => void
+  isSupabaseConnected: boolean
+  syncStatus: SyncStatus
+  lastSyncedAt: Date | null
+  connectSupabase: (url: string, anonKey: string) => Promise<void>
+  disconnectSupabase: () => Promise<void>
 }
 
 const noop = () => undefined
 
+const defaultStorage = new StorageManager(new LocalStorageAdapter())
+
 export const StorageContext = React.createContext<Storage>({
-  data: storage.defaultData,
+  data: defaultStorage.defaultData,
   labelsById: {},
-  sections: storage.defaultData.sections,
-  storage,
+  sections: defaultStorage.defaultData.sections,
+  storage: defaultStorage,
   fetchData: noop,
   addTask: noop,
   updateTask: noop,
@@ -44,11 +74,48 @@ export const StorageContext = React.createContext<Storage>({
   updateFilters: noop,
   uploadData: noop,
   updateSection: noop,
-  updateSections: noop
+  updateSections: noop,
+  isSupabaseConnected: false,
+  syncStatus: "idle",
+  lastSyncedAt: null,
+  connectSupabase: () => Promise.resolve(),
+  disconnectSupabase: () => Promise.resolve()
 })
 
-function StorageProvider({ children }: PropsWithChildren<unknown>): any {
+function StorageProvider({
+  children
+}: PropsWithChildren<unknown>): React.ReactNode {
+  // Lazy-init: create the adapter and StorageManager once on first render
+  const storageRef = useRef<StorageManager | null>(null)
+  const initialAdapterRef = useRef<StorageAdapter | null>(null)
+  if (!storageRef.current) {
+    const adapter = createInitialAdapter()
+    initialAdapterRef.current = adapter
+    storageRef.current = new StorageManager(adapter)
+  }
+  const storage = storageRef.current
+
   const [data, setDataFn] = React.useState<Data>(storage.defaultData)
+  const [isSupabaseConnected, setIsSupabaseConnected] = useState(
+    () => getSupabaseConfig() !== null
+  )
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>("idle")
+  const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null)
+
+  const attachSyncListener = useCallback((adapter: DebouncedAdapter) => {
+    adapter.onSyncChange((status, syncedAt) => {
+      setSyncStatus(status)
+      if (syncedAt) setLastSyncedAt(syncedAt)
+    })
+  }, [])
+
+  // Attach listener to the initial adapter if it's debounced (Supabase)
+  React.useEffect(() => {
+    const adapter = initialAdapterRef.current
+    if (adapter instanceof DebouncedAdapter) {
+      attachSyncListener(adapter)
+    }
+  }, [attachSyncListener])
 
   function setData(data: Data) {
     setDataFn(data)
@@ -62,6 +129,47 @@ function StorageProvider({ children }: PropsWithChildren<unknown>): any {
 
   const dataRef = React.useRef(data)
   dataRef.current = data
+
+  const connectSupabase = async (url: string, anonKey: string) => {
+    // Create and test the new adapter
+    const rawAdapter = new SupabaseStorageAdapter(url, anonKey)
+    if (rawAdapter.testConnection) {
+      await rawAdapter.testConnection()
+    }
+
+    // Migrate from current local data to Supabase
+    const currentAdapter = new LocalStorageAdapter()
+    await migrateData(currentAdapter, rawAdapter)
+
+    // Wrap in debounced adapter to coalesce rapid writes
+    const newAdapter = new DebouncedAdapter(rawAdapter)
+    attachSyncListener(newAdapter)
+
+    // Persist config and swap — only after migration succeeds
+    setSupabaseConfig({ url, anonKey })
+    storage.setAdapter(newAdapter)
+    setIsSupabaseConnected(true)
+
+    // Reload data from the new adapter
+    fetchData()
+  }
+
+  const disconnectSupabase = async () => {
+    const localAdapter = new LocalStorageAdapter()
+
+    // Copy current Supabase data to localStorage before disconnecting
+    const currentData = data
+    await localAdapter.set(currentData)
+
+    clearSupabaseConfig()
+    storage.setAdapter(localAdapter)
+    setIsSupabaseConnected(false)
+    setSyncStatus("idle")
+    setLastSyncedAt(null)
+
+    // Refresh UI from the local adapter
+    fetchData()
+  }
 
   function useAction<A, B = any>(
     fn: (data: Data, dataType: A, otherType?: B) => Data
@@ -121,7 +229,12 @@ function StorageProvider({ children }: PropsWithChildren<unknown>): any {
     updateTask,
     updateSection,
     updateSections,
-    uploadData: storage.uploadData
+    uploadData: storage.uploadData,
+    isSupabaseConnected,
+    syncStatus,
+    lastSyncedAt,
+    connectSupabase,
+    disconnectSupabase
   }
 
   return (

--- a/src/context/StorageContext.tsx
+++ b/src/context/StorageContext.tsx
@@ -4,14 +4,17 @@ import React, { PropsWithChildren, useCallback, useRef, useState } from "react"
 import StorageManager from "../StorageManager"
 import { StorageAdapter } from "../adapters/StorageAdapter"
 import { LocalStorageAdapter } from "../adapters/LocalStorageAdapter"
+import { AppSupabaseAdapter } from "../adapters/AppSupabaseAdapter"
 import { SupabaseStorageAdapter } from "../adapters/SupabaseStorageAdapter"
 import { DebouncedAdapter, SyncStatus } from "../adapters/DebouncedAdapter"
 import { migrateData } from "../adapters/migrateData"
+import { mergeData } from "../adapters/mergeData"
 import {
   getSupabaseConfig,
   setSupabaseConfig,
   clearSupabaseConfig
 } from "../adapters/supabaseConfig"
+import { useAuth } from "./AuthContext"
 
 function createInitialAdapter(): StorageAdapter {
   const config = getSupabaseConfig()
@@ -21,7 +24,6 @@ function createInitialAdapter(): StorageAdapter {
         new SupabaseStorageAdapter(config.url, config.anonKey)
       )
     } catch {
-      // Invalid stored config — fall back to localStorage
       clearSupabaseConfig()
     }
   }
@@ -51,6 +53,8 @@ interface Storage {
   lastSyncedAt: Date | null
   connectSupabase: (url: string, anonKey: string) => Promise<void>
   disconnectSupabase: () => Promise<void>
+  dataConflict: { local: Data; remote: Data } | null
+  resolveConflict: (choice: "remote" | "merge") => void
 }
 
 const noop = () => undefined
@@ -79,13 +83,16 @@ export const StorageContext = React.createContext<Storage>({
   syncStatus: "idle",
   lastSyncedAt: null,
   connectSupabase: () => Promise.resolve(),
-  disconnectSupabase: () => Promise.resolve()
+  disconnectSupabase: () => Promise.resolve(),
+  dataConflict: null,
+  resolveConflict: noop
 })
 
 function StorageProvider({
   children
 }: PropsWithChildren<unknown>): React.ReactNode {
-  // Lazy-init: create the adapter and StorageManager once on first render
+  const { isAuthenticated } = useAuth()
+
   const storageRef = useRef<StorageManager | null>(null)
   const initialAdapterRef = useRef<StorageAdapter | null>(null)
   if (!storageRef.current) {
@@ -101,6 +108,11 @@ function StorageProvider({
   )
   const [syncStatus, setSyncStatus] = useState<SyncStatus>("idle")
   const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null)
+  const [dataConflict, setDataConflict] = useState<{
+    local: Data
+    remote: Data
+    adapter: AppSupabaseAdapter
+  } | null>(null)
 
   const attachSyncListener = useCallback((adapter: DebouncedAdapter) => {
     adapter.onSyncChange((status, syncedAt) => {
@@ -109,7 +121,6 @@ function StorageProvider({
     })
   }, [])
 
-  // Attach listener to the initial adapter if it's debounced (Supabase)
   React.useEffect(() => {
     const adapter = initialAdapterRef.current
     if (adapter instanceof DebouncedAdapter) {
@@ -121,45 +132,98 @@ function StorageProvider({
     setDataFn(data)
   }
 
-  const fetchData = () => {
+  const fetchData = useCallback(() => {
     storage.getData().then(({ data }) => {
       setData(data)
     })
-  }
+  }, [storage])
 
   const dataRef = React.useRef(data)
   dataRef.current = data
 
+  // Switch adapter when auth state changes.
+  // Custom Supabase (Layer 2) takes priority — only switch to AppSupabaseAdapter
+  // if the user hasn't connected their own project.
+  React.useEffect(() => {
+    if (getSupabaseConfig()) return
+
+    if (isAuthenticated) {
+      const appAdapter = new AppSupabaseAdapter()
+      const newAdapter = new DebouncedAdapter(appAdapter)
+      attachSyncListener(newAdapter)
+
+      const localAdapter = new LocalStorageAdapter()
+
+      Promise.all([localAdapter.get(), appAdapter.get()]).then(
+        ([local, remote]) => {
+          const hasLocal =
+            local && Object.values(local.tasks ?? {}).flat().length > 0
+          const hasRemote =
+            remote && Object.values(remote.tasks ?? {}).flat().length > 0
+
+          if (hasLocal && hasRemote) {
+            // Both have data — let the user decide
+            setDataConflict({ local, remote, adapter: appAdapter })
+            storage.setAdapter(newAdapter)
+            fetchData()
+          } else if (hasLocal && !hasRemote) {
+            // Only local data — migrate it up
+            migrateData(localAdapter, appAdapter).finally(() => {
+              storage.setAdapter(newAdapter)
+              fetchData()
+            })
+          } else {
+            // No local data or only remote — just switch
+            storage.setAdapter(newAdapter)
+            fetchData()
+          }
+        }
+      )
+    } else {
+      storage.setAdapter(new LocalStorageAdapter())
+      setSyncStatus("idle")
+      setLastSyncedAt(null)
+      setDataConflict(null)
+      fetchData()
+    }
+  }, [isAuthenticated, attachSyncListener, storage, fetchData])
+
+  const resolveConflict = useCallback(
+    (choice: "remote" | "merge") => {
+      if (!dataConflict) return
+      const { local, remote, adapter } = dataConflict
+      const resolved = choice === "merge" ? mergeData(local, remote) : remote
+      adapter.set(resolved).then(() => {
+        new LocalStorageAdapter().clear()
+        setDataConflict(null)
+        fetchData()
+      })
+    },
+    [dataConflict, fetchData]
+  )
+
   const connectSupabase = async (url: string, anonKey: string) => {
-    // Create and test the new adapter
     const rawAdapter = new SupabaseStorageAdapter(url, anonKey)
     if (rawAdapter.testConnection) {
       await rawAdapter.testConnection()
     }
 
-    // Migrate from current local data to Supabase
     const currentAdapter = new LocalStorageAdapter()
     await migrateData(currentAdapter, rawAdapter)
 
-    // Wrap in debounced adapter to coalesce rapid writes
     const newAdapter = new DebouncedAdapter(rawAdapter)
     attachSyncListener(newAdapter)
 
-    // Persist config and swap — only after migration succeeds
     setSupabaseConfig({ url, anonKey })
     storage.setAdapter(newAdapter)
     setIsSupabaseConnected(true)
 
-    // Reload data from the new adapter
     fetchData()
   }
 
   const disconnectSupabase = async () => {
     const localAdapter = new LocalStorageAdapter()
-
-    // Copy current Supabase data to localStorage before disconnecting
-    const currentData = data
-    await localAdapter.set(currentData)
+    await localAdapter.set(data)
 
     clearSupabaseConfig()
     storage.setAdapter(localAdapter)
@@ -167,7 +231,6 @@ function StorageProvider({
     setSyncStatus("idle")
     setLastSyncedAt(null)
 
-    // Refresh UI from the local adapter
     fetchData()
   }
 
@@ -185,26 +248,21 @@ function StorageProvider({
         dataRef.current = newData
         setData(newData)
       },
-
       [fn]
     )
   }
 
-  // Callbacks for tasks
   const addTask = useAction<Task>(storage.addTask)
   const updateTask = useAction<Task>(storage.updateTask)
   const removeTask = useAction<Task>(storage.removeTask)
   const moveToToday = useAction<Task>(storage.moveTaskToToday)
 
-  // Callbacks for labels
   const addLabel = useAction<Label>(storage.addLabel)
   const removeLabel = useAction<Label>(storage.removeLabel)
   const updateLabel = useAction<Label>(storage.updateLabel)
 
-  // Callbacks for filters
   const updateFilters = useAction<Filters>(storage.updateFilters)
 
-  // Callbacks for sections
   const updateSection = useAction<Section, any>(storage.updateSection)
   const updateSections = useAction<Record<string, SectionData>>(
     storage.updateSections
@@ -234,7 +292,11 @@ function StorageProvider({
     syncStatus,
     lastSyncedAt,
     connectSupabase,
-    disconnectSupabase
+    disconnectSupabase,
+    dataConflict: dataConflict
+      ? { local: dataConflict.local, remote: dataConflict.remote }
+      : null,
+    resolveConflict
   }
 
   return (

--- a/src/hooks/__tests__/useSchemaCheck.test.ts
+++ b/src/hooks/__tests__/useSchemaCheck.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { useSchemaCheck } from "../useSchemaCheck"
+import { SCHEMA_VERSION } from "../../StorageManager"
+import { Data } from "../../index.d"
+
+const makeData = (schemaVersion?: number): Data => ({
+  schemaVersion,
+  filters: [],
+  tasks: {},
+  labels: [],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+})
+
+describe("useSchemaCheck", () => {
+  it("returns false when not a custom Supabase connection", () => {
+    const data = makeData(0)
+    expect(useSchemaCheck(data, false)).toBe(false)
+  })
+
+  it("returns false when schema version matches current", () => {
+    const data = makeData(SCHEMA_VERSION)
+    expect(useSchemaCheck(data, true)).toBe(false)
+  })
+
+  it("returns true when schema version is missing", () => {
+    const data = makeData(undefined)
+    expect(useSchemaCheck(data, true)).toBe(true)
+  })
+
+  it("returns true when schema version is behind current", () => {
+    const data = makeData(SCHEMA_VERSION - 1)
+    expect(useSchemaCheck(data, true)).toBe(true)
+  })
+
+  it("returns false when schema version is ahead of current", () => {
+    const data = makeData(SCHEMA_VERSION + 1)
+    expect(useSchemaCheck(data, true)).toBe(false)
+  })
+})

--- a/src/hooks/useSchemaCheck.ts
+++ b/src/hooks/useSchemaCheck.ts
@@ -1,0 +1,12 @@
+import { SCHEMA_VERSION } from "../StorageManager"
+import { Data } from "../index.d"
+
+/**
+ * Returns true if the loaded data has a schema version older than the current
+ * app version. Only relevant for users who bring their own Supabase — their DB
+ * schema may be out of date and require a manual migration.
+ */
+export function useSchemaCheck(data: Data, isCustomSupabase: boolean): boolean {
+  if (!isCustomSupabase) return false
+  return (data.schemaVersion ?? 0) < SCHEMA_VERSION
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,7 @@ export type Tasks = Record<string, Task[]>
 export type Filters = string[]
 
 export type Data = {
+  schemaVersion?: number
   filters: Filters
   tasks: Tasks
   labels: Label[]

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,11 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as
+  | string
+  | undefined
+
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- what-todo.app — Supabase schema
+-- Run this in the Supabase SQL editor to set up the database.
+-- ============================================================
+
+
+-- ------------------------------------------------------------
+-- Users
+-- Auto-populated via trigger on auth.users insert.
+-- api_token is issued to the user for MCP server access.
+-- supabase_url is set if the user connects their own project.
+-- ------------------------------------------------------------
+
+CREATE TABLE users (
+  id          UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email       TEXT,
+  api_token   UUID NOT NULL DEFAULT gen_random_uuid(),
+  supabase_url TEXT,
+  created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own row" ON users
+  FOR SELECT USING (auth.uid() = id);
+
+
+-- ------------------------------------------------------------
+-- Trigger: create a user row on sign-up
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO users (id, email)
+  VALUES (NEW.id, NEW.email);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+
+-- ------------------------------------------------------------
+-- Todos
+-- Stores the full data blob per user (mirrors the localStorage
+-- structure). Used when the user is authenticated and has not
+-- connected their own Supabase project.
+-- ------------------------------------------------------------
+
+CREATE TABLE todos (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at  TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE todos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own todos" ON todos
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+ALTER TABLE todos ADD CONSTRAINT todos_user_id_unique UNIQUE (user_id);
+
+
+-- ------------------------------------------------------------
+-- User's own Supabase project schema
+-- Run this in the SQL editor of the USER'S Supabase project,
+-- not the what-todo.app project.
+-- ------------------------------------------------------------
+
+-- CREATE TABLE what_todo_data (
+--   id          TEXT PRIMARY KEY DEFAULT 'default',
+--   user_id     UUID NOT NULL DEFAULT auth.uid(),
+--   data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+--   updated_at  TIMESTAMPTZ DEFAULT now()
+-- );
+--
+-- ALTER TABLE what_todo_data ENABLE ROW LEVEL SECURITY;
+--
+-- CREATE POLICY "Owner access" ON what_todo_data
+--   FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -66,6 +66,23 @@ ALTER TABLE todos ADD CONSTRAINT todos_user_id_unique UNIQUE (user_id);
 
 
 -- ------------------------------------------------------------
+-- Waitlist
+-- Stores emails from users who requested early access.
+-- ------------------------------------------------------------
+
+CREATE TABLE waitlist (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       TEXT NOT NULL UNIQUE,
+  created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can join waitlist" ON waitlist
+  FOR INSERT WITH CHECK (true);
+
+
+-- ------------------------------------------------------------
 -- User's own Supabase project schema
 -- Run this in the SQL editor of the USER'S Supabase project,
 -- not the what-todo.app project.


### PR DESCRIPTION
Introduces a pluggable storage adapter pattern and a three-tier data model: anonymous users get localStorage, authenticated users get the app's Supabase instance, and advanced users can connect their own Supabase project for full data ownership. StorageManager now accepts any adapter conforming to a minimal `get/set/clear` interface, swapping backends at runtime when auth state or Supabase config changes. Signing in migrates localStorage data up to the app's DB, with a conflict resolution sheet if both sides have data. Schema versioning is stamped on every write so custom Supabase users can be warned when a DB migration is needed.

Also ships Google OAuth with an early access waitlist (signup_disabled surfaces a sheet instead of a toast), a cleaned-up header with user menu, mobile layout fixes, an /mcp discovery pill, and a data merge utility. To test: sign in with Google, verify todos persist across refresh, sign out and confirm localStorage fallback, then connect a custom Supabase project and confirm the schema outdated warning appears when schemaVersion is behind.