### PR TITLE
Add fluid section animations and hover-to-show toggles

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -19,6 +19,7 @@ import colors from "../color-palette"
 import { useStorage } from "../context/StorageContext"
 import Label from "./Label"
 import ToggleButton from "./ToggleButton"
+import { AnimatePresence, motion } from "framer-motion"
 
 function Title({ children }: PropsWithChildren) {
   return (
@@ -52,6 +53,9 @@ const getOlderTasks = (data: Data): Task[] => {
 const mobilePadding = 3
 const padding = 4
 const paddingTop = 2
+
+// Content fade/slide animation shared by both sidebars
+const contentTransition = { duration: 0.25, ease: [0.4, 0, 0.2, 1] }
 
 const Todo: React.FC = ({}) => {
   const breakpoint = useMedia()
@@ -132,6 +136,9 @@ const Todo: React.FC = ({}) => {
 
   const fullHeight = "calc(100dvh - 66px)"
 
+  const isDesktop =
+    breakpoint != Breakpoints.MOBILE && breakpoint != Breakpoints.TABLET
+
   const completedContent = !completed.collapsed && (
     <Flex
       width={grid.completed}
@@ -140,74 +147,95 @@ const Todo: React.FC = ({}) => {
       pt={paddingTop}
       flexDirection="column"
       className="bg-slate-50/60 dark:bg-navy-800"
+      style={{ overflow: "hidden" }}
     >
-      <div className="pb-1">
-        <Title>Completed</Title>
-        <Subtitle>{formatDateHeading(todayDateStr)}</Subtitle>
-      </div>
+      <AnimatePresence>
+        <motion.div
+          key="completed-content"
+          initial={{ opacity: 0, x: -12 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -12 }}
+          transition={contentTransition}
+          style={{ display: "flex", flexDirection: "column", flex: 1 }}
+        >
+          <div className="pb-1">
+            <Title>Completed</Title>
+            <Subtitle>{formatDateHeading(todayDateStr)}</Subtitle>
+          </div>
 
-      {data.filters.length > 0 && (
-        <div className="my-2">
-          <small>Showing: </small>
-          {data.filters.map(id => (
-            <div className="inline mb-1 mr-1" key={id}>
-              <Label
-                active
-                label={labelsById[id]}
-                onRemove={() => {
-                  updateFilters(data.filters.filter(x => x !== id))
-                }}
+          {data.filters.length > 0 && (
+            <div className="my-2">
+              <small>Showing: </small>
+              {data.filters.map(id => (
+                <div className="inline mb-1 mr-1" key={id}>
+                  <Label
+                    active
+                    label={labelsById[id]}
+                    onRemove={() => {
+                      updateFilters(data.filters.filter(x => x !== id))
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="w-full overflow-y-auto flex-[2]">
+            <div>
+              <List
+                tasks={yesterdaysTasks}
+                labels={labelsById}
+                filters={data.filters}
+                collapseCompleted={true}
+                canPinTasks={false}
+                canCollapse={false}
+                onFilter={updateFilters}
+                onUpdateTask={handleUpdateTask}
+                onRemoveTask={handleRemoveTask}
+                onMarkAsComplete={markAsComplete}
+                onMoveToToday={handleMoveToToday}
               />
             </div>
-          ))}
-        </div>
-      )}
+          </div>
 
-      <div className="w-full overflow-y-auto flex-[2]">
-        <div>
-          <List
-            tasks={yesterdaysTasks}
-            labels={labelsById}
-            filters={data.filters}
-            collapseCompleted={true}
-            canPinTasks={false}
-            canCollapse={false}
-            onFilter={updateFilters}
-            onUpdateTask={handleUpdateTask}
-            onRemoveTask={handleRemoveTask}
-            onMarkAsComplete={markAsComplete}
-            onMoveToToday={handleMoveToToday}
-          />
-        </div>
-      </div>
-
-      <div className="pt-3">
-        <TaskInput
-          placeholder="Forget something?"
-          labels={data.labels}
-          filters={data.filters}
-          onAdd={task => handleAddTask(task, yesterday())}
-        />
-      </div>
+          <div className="pt-3">
+            <TaskInput
+              placeholder="Forget something?"
+              labels={data.labels}
+              filters={data.filters}
+              onAdd={task => handleAddTask(task, yesterday())}
+            />
+          </div>
+        </motion.div>
+      </AnimatePresence>
     </Flex>
-  )
-
-  const completedToggle = (
-    <div className="flex items-center" style={{ height: fullHeight }}>
-      <ToggleButton
-        collapsed={completed.collapsed}
-        side="left"
-        onClick={() => updateSection("completed", { collapsed: !completed.collapsed })}
-      />
-    </div>
   )
 
   return (
     <main>
       <div className="flex">
-        {breakpoint != Breakpoints.MOBILE && breakpoint != Breakpoints.TABLET
-          ? <>{completedContent}{completedToggle}</>
-          : null}
+        {isDesktop && completedContent}
+
+        {isDesktop && (
+          <div
+            className={`flex items-center transition-opacity duration-200 ${
+              completed.collapsed
+                ? "opacity-100"
+                : "opacity-0 hover:opacity-100"
+            }`}
+            style={{ height: fullHeight }}
+          >
+            <ToggleButton
+              collapsed={completed.collapsed}
+              side="left"
+              onClick={() =>
+                updateSection("completed", {
+                  collapsed: !completed.collapsed
+                })
+              }
+            />
+          </div>
+        )}
 
         <Flex
           width={grid.focus}
@@ -262,48 +290,67 @@ const Todo: React.FC = ({}) => {
           </div>
         </Flex>
 
-        {breakpoint != Breakpoints.MOBILE && breakpoint != Breakpoints.TABLET && (
-          <>
-            <div className="flex items-center" style={{ height: fullHeight }}>
-              <ToggleButton
-                collapsed={sidebar.collapsed}
-                side="right"
-                onClick={() => updateSection("sidebar", { collapsed: !sidebar.collapsed })}
-              />
-            </div>
-            {!sidebar.collapsed && (
+        {isDesktop && (
+          <div
+            className={`flex items-center transition-opacity duration-200 ${
+              sidebar.collapsed
+                ? "opacity-100"
+                : "opacity-0 hover:opacity-100"
+            }`}
+            style={{ height: fullHeight }}
+          >
+            <ToggleButton
+              collapsed={sidebar.collapsed}
+              side="right"
+              onClick={() =>
+                updateSection("sidebar", {
+                  collapsed: !sidebar.collapsed
+                })
+              }
+            />
+          </div>
+        )}
+        {isDesktop && !sidebar.collapsed && (
               <Flex
                 width={grid.sidebar}
                 p={padding}
                 pt={paddingTop}
                 height={fullHeight}
                 className="bg-slate-50/60 dark:bg-navy-800"
+                style={{ overflow: "hidden" }}
               >
-                <div className="flex flex-col flex-grow justify-start">
-                  <div className="pb-1">
-                    <Title>Labels</Title>
-                  </div>
+                <AnimatePresence>
+                  <motion.div
+                    key="sidebar-content"
+                    initial={{ opacity: 0, x: 12 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: 12 }}
+                    transition={contentTransition}
+                    className="flex flex-col flex-grow justify-start"
+                  >
+                    <div className="pb-1">
+                      <Title>Labels</Title>
+                    </div>
 
-                  <div className="flex-1 overflow-y-scroll pb-2">
-                    <Labels
-                      labels={data.labels}
-                      limit={15}
-                      colors={colors}
-                      filters={data.filters}
-                      onFilter={updateFilters}
-                      onAddLabel={handleAddLabel}
-                      onUpdateLabel={handleUpdateLabel}
-                      onRemoveLabel={handleRemoveLabel}
-                    />
-                  </div>
+                    <div className="flex-1 overflow-y-scroll pb-2">
+                      <Labels
+                        labels={data.labels}
+                        limit={15}
+                        colors={colors}
+                        filters={data.filters}
+                        onFilter={updateFilters}
+                        onAddLabel={handleAddLabel}
+                        onUpdateLabel={handleUpdateLabel}
+                        onRemoveLabel={handleRemoveLabel}
+                      />
+                    </div>
 
-                  <div className="h-[55px]">
-                    <Footer />
-                  </div>
-                </div>
+                    <div className="h-[55px]">
+                      <Footer />
+                    </div>
+                  </motion.div>
+                </AnimatePresence>
               </Flex>
-            )}
-          </>
         )}
       </div>
     </main>


### PR DESCRIPTION
## Summary

The Completed and Labels sidebar sections currently appear/disappear abruptly when toggled. The toggle buttons are always visible even when not needed.

## Approach

Keep the original Rebass layout system completely intact — no width animation attempts. Instead, animate only the **content** inside each sidebar with framer-motion (opacity fade + slight translateX slide):

- Completed section content slides in from the left (`x: -12 → 0`) and fades in
- Labels section content slides in from the right (`x: 12 → 0`) and fades in
- Both use shared timing: 250ms with Material Design easing
- Toggle buttons hidden by default, shown on hover via pure CSS `group-hover` — no React state
- When a section is collapsed, its toggle button stays always visible for re-expanding

This approach avoids all the pitfalls of animating Rebass/Emotion CSS-class-based widths, and produces a clean, fluid feel.

Co-authored-by: Claude <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>
