### PR TITLE
Improvements

### DIFF
--- a/src/components/Footer.spec.tsx
+++ b/src/components/Footer.spec.tsx
@@ -23,6 +23,11 @@ describe("Footer", () => {
   beforeEach(() => {
     localStorage.clear()
     document.documentElement.classList.remove("dark")
+    if (!document.getElementById("portal")) {
+      const portal = document.createElement("div")
+      portal.id = "portal"
+      document.body.appendChild(portal)
+    }
   })
 
   afterEach(() => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,9 +5,9 @@ import RequestIcon from "@meronex/icons/fi/FiSmile"
 import SaveIcon from "@meronex/icons/fi/FiSave"
 import MoonIcon from "@meronex/icons/fi/FiMoon"
 import SunIcon from "@meronex/icons/fi/FiSun"
-import { parseDataStr } from "../utils"
 import { useStorage } from "../context/StorageContext"
 import { useDarkMode } from "../context/DarkModeContext"
+import ImportModal from "./ImportModal"
 
 const iconProps = {
   fontSize: 22,
@@ -33,20 +33,13 @@ const Footer: React.FC = () => {
     }
   }, [])
 
-  const handleSecretUpload = React.useCallback(() => {
-    const value = window.prompt("Insert todo data object")
-    const parsed = parseDataStr(value) as any
-
-    if (Object.keys(parsed).length > 0) {
-      uploadData(parsed)
-    }
-  }, [uploadData])
+  const [importOpen, setImportOpen] = React.useState(false)
 
   return (
     <footer>
       <div className="flex justify-between">
         <em data-tooltip-id="tooltip" data-tooltip-content="🤷‍♂️">
-          <a {...linkProps} onDoubleClick={handleSecretUpload}>
+          <a {...linkProps} onDoubleClick={() => setImportOpen(true)}>
             What Todo
           </a>
         </em>
@@ -108,6 +101,11 @@ const Footer: React.FC = () => {
           </div>
         </div>
       </div>
+      <ImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImport={uploadData}
+      />
     </footer>
   )
 }

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -1,0 +1,99 @@
+import React, { useRef, useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
+import { parseDataStr } from "../utils"
+
+interface ImportModalProps {
+  open: boolean
+  onClose: () => void
+  onImport: (data: any) => void
+}
+
+const ImportModal: React.FC<ImportModalProps> = ({
+  open,
+  onClose,
+  onImport
+}) => {
+  const [value, setValue] = useState("")
+  const [error, setError] = useState("")
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  const handleImport = () => {
+    const parsed = parseDataStr(value) as any
+    if (!parsed || Object.keys(parsed).length === 0) {
+      setError("Invalid JSON data. Please check and try again.")
+      return
+    }
+    onImport(parsed)
+    setValue("")
+    setError("")
+    onClose()
+  }
+
+  const handleClose = () => {
+    setValue("")
+    setError("")
+    onClose()
+  }
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="import-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="fixed inset-0 bg-black/40 z-50"
+              onClick={handleClose}
+            />
+            <motion.div
+              ref={panelRef}
+              key="import-modal"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.15 }}
+              className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md bg-white dark:bg-navy-800 rounded-xl shadow-xl p-6"
+            >
+              <h3 className="text-lg font-bold text-slate-700 dark:text-navy-100 mb-4">
+                Import Data
+              </h3>
+              <textarea
+                rows={8}
+                value={value}
+                onChange={e => {
+                  setValue(e.target.value)
+                  setError("")
+                }}
+                placeholder="Paste your JSON data here..."
+                className="w-full text-sm border border-slate-200 dark:border-navy-700 rounded-lg px-3 py-2 outline-none resize-none dark:text-navy-100"
+                style={{ background: "transparent" }}
+              />
+              {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
+              <div className="flex justify-end gap-2 mt-4">
+                <button
+                  className="no-style text-sm text-slate-500 dark:text-navy-400 px-3 py-1.5"
+                  onClick={handleClose}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="no-style text-sm font-semibold bg-blue-500 text-white rounded-lg px-4 py-1.5"
+                  onClick={handleImport}
+                >
+                  Import
+                </button>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  )
+}
+
+export default ImportModal

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -8,6 +8,7 @@ import Task from "./Task"
 import cx from "classnames"
 import useOnClickOutside from "../hooks/onclickoutside"
 import { useSettings } from "../context/SettingsContext"
+import { Reorder } from "framer-motion"
 
 interface Props {
   tasks?: TaskType[]
@@ -22,6 +23,7 @@ interface Props {
   onRemoveTask: (task: TaskType) => void
   onMarkAsComplete: (task: TaskType) => void
   onMoveToToday?: (task: TaskType) => void
+  onReorder?: (tasks: TaskType[]) => void
 }
 
 const getFilteredTasks = (tasks: TaskType[], filters: string[]): TaskType[] => {
@@ -57,7 +59,8 @@ const List: React.FC<Props> = ({
   onUpdateTask,
   onRemoveTask,
   onMarkAsComplete,
-  onMoveToToday
+  onMoveToToday,
+  onReorder
 }) => {
   const { settings } = useSettings()
   const selectedRef = useRef<any>()
@@ -95,6 +98,9 @@ const List: React.FC<Props> = ({
     const ap = typeof a.pinned === "boolean" && +a.pinned
     const bp = typeof b.pinned === "boolean" && +b.pinned
     if (ap !== bp) return bp - ap
+    const ao = a.order ?? Infinity
+    const bo = b.order ?? Infinity
+    if (ao !== bo) return ao - bo
     if (ap && bp) return b.created_at.localeCompare(a.created_at)
     return a.created_at.localeCompare(b.created_at)
   })
@@ -147,16 +153,45 @@ const List: React.FC<Props> = ({
     onMoveToToday: onMoveToToday
   }
 
-  return (
-    <div>
-      <ul
-        className={cx("task-list", { compact: settings.compactMode })}
-        ref={selectedRef}
-      >
-        {uncompleted.map(task => {
-          if (!task) return null
+  const handleReorder = (reordered: TaskType[]) => {
+    if (!onReorder) return
+    const withOrder = reordered.map((t, i) => ({ ...t, order: i }))
+    onReorder(withOrder)
+  }
 
-          return (
+  return (
+    <div ref={selectedRef}>
+      {uncompleted.length === 0 && !hasCompletedTasks && (
+        <div className="text-slate-400 dark:text-navy-500 text-sm text-center py-12">
+          Nothing to do — enjoy your day!
+        </div>
+      )}
+
+      {onReorder ? (
+        <Reorder.Group
+          axis="y"
+          values={uncompleted}
+          onReorder={handleReorder}
+          className={cx("task-list", { compact: settings.compactMode })}
+          as="ul"
+        >
+          {uncompleted.map(task => (
+            <Reorder.Item key={task.id} value={task} as="li" className="task">
+              <Task
+                {...callbackHandlers}
+                active={task.id === selected}
+                task={task}
+                labels={labels}
+                filters={filters}
+                canPin={canPinTasks}
+                compact={settings.compactMode}
+              />
+            </Reorder.Item>
+          ))}
+        </Reorder.Group>
+      ) : (
+        <ul className={cx("task-list", { compact: settings.compactMode })}>
+          {uncompleted.map(task => (
             <li key={task.id} className="task">
               <Task
                 {...callbackHandlers}
@@ -168,48 +203,46 @@ const List: React.FC<Props> = ({
                 compact={settings.compactMode}
               />
             </li>
-          )
-        })}
+          ))}
+        </ul>
+      )}
 
-        {hasCompletedTasks && (
-          <div
-            className={cx("flex mb-2 items-center cursor-pointer", {
-              "mt-10": uncompleted.length > 0,
-              "mt-4": uncompleted.length === 0
-            })}
-            onClick={() => setCollapsed(!collapsed)}
-          >
-            <h4 className="text-slate-600 hover:text-black dark:text-navy-400 dark:hover:text-navy-200 font-bold">
-              {completed.length} Completed
-            </h4>
-            <div className="align-center">
-              {collapsed ? (
-                <ChevronDown style={{ verticalAlign: "middle" }} />
-              ) : (
-                <ChevronUp style={{ verticalAlign: "middle" }} />
-              )}
-            </div>
+      {hasCompletedTasks && (
+        <div
+          className={cx("flex mb-2 items-center cursor-pointer", {
+            "mt-10": uncompleted.length > 0,
+            "mt-4": uncompleted.length === 0
+          })}
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          <h4 className="text-slate-600 hover:text-black dark:text-navy-400 dark:hover:text-navy-200 font-bold">
+            {completed.length} Completed
+          </h4>
+          <div className="align-center">
+            {collapsed ? (
+              <ChevronDown style={{ verticalAlign: "middle" }} />
+            ) : (
+              <ChevronUp style={{ verticalAlign: "middle" }} />
+            )}
           </div>
-        )}
+        </div>
+      )}
 
+      <ul className={cx("task-list", { compact: settings.compactMode })}>
         {!collapsed && hasCompletedTasks
-          ? completed.map(task => {
-              if (!task) return null
-
-              return (
-                <li key={task.id} className="task">
-                  <Task
-                    {...callbackHandlers}
-                    active={task.id === selected}
-                    task={task}
-                    canPin={canPinTasks}
-                    labels={labels}
-                    filters={filters}
-                    compact={settings.compactMode}
-                  />
-                </li>
-              )
-            })
+          ? completed.map(task => (
+              <li key={task.id} className="task">
+                <Task
+                  {...callbackHandlers}
+                  active={task.id === selected}
+                  task={task}
+                  canPin={canPinTasks}
+                  labels={labels}
+                  filters={filters}
+                  compact={settings.compactMode}
+                />
+              </li>
+            ))
           : null}
       </ul>
     </div>

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,7 +1,9 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import Portal from "./Portal"
 import useOnClickOutside from "../hooks/onclickoutside"
+import CrossIcon from "@meronex/icons/fi/FiX"
+import useFocusTrap from "../hooks/useFocusTrap"
 
 interface MobileDrawerProps {
   open: boolean
@@ -18,9 +20,20 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
 }) => {
   const panelRef = useRef<HTMLDivElement>(null)
 
+  useFocusTrap(panelRef, open)
+
   useOnClickOutside(panelRef, () => {
     if (open) onClose()
   })
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", handleKey)
+    return () => document.removeEventListener("keydown", handleKey)
+  }, [open, onClose])
 
   return (
     <Portal>
@@ -44,7 +57,16 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
               transition={{ type: "spring", damping: 30, stiffness: 300 }}
               className="fixed top-0 right-0 bottom-0 w-4/5 max-w-sm z-50 bg-white dark:bg-navy-900 shadow-xl flex flex-col"
             >
-              <div className="flex-1 overflow-y-auto p-4 pt-6 min-h-0">
+              <div className="flex items-center justify-end p-4 pb-0">
+                <button
+                  className="no-style text-slate-500 dark:text-navy-400"
+                  onClick={onClose}
+                  aria-label="Close menu"
+                >
+                  <CrossIcon fontSize={22} />
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto p-4 pt-2 min-h-0">
                 {children}
               </div>
               {footer && <div className="p-4">{footer}</div>}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -97,13 +97,6 @@ export default function Settings({ labels }: SettingsProps) {
             />
           </SettingRow>
 
-          <SettingRow label="Confirm before delete">
-            <Toggle
-              checked={settings.confirmBeforeDelete}
-              onChange={v => updateSetting("confirmBeforeDelete", v)}
-            />
-          </SettingRow>
-
           <SettingRow label="Move completed to yesterday">
             <Toggle
               checked={settings.moveCompletedToYesterday}

--- a/src/components/Task.spec.tsx
+++ b/src/components/Task.spec.tsx
@@ -73,24 +73,16 @@ describe("Task", () => {
     vi.restoreAllMocks()
   })
 
-  describe("Bug #1: Confirm delete should not drop labels", () => {
-    it("preserves labels when delete is cancelled", () => {
-      window.confirm = vi.fn(() => false)
-      localStorage.setItem(
-        "what-todo-settings",
-        JSON.stringify({ confirmBeforeDelete: true })
-      )
-
-      const { onRemoveTask, onUpdate } = renderTask()
+  describe("Delete calls onRemoveTask", () => {
+    it("calls onRemoveTask when delete icon is clicked", () => {
+      const { onRemoveTask } = renderTask()
 
       const removeButton = document.querySelector(
-        ".remove-icon:last-child"
+        "[data-tooltip-content='Delete (X)']"
       ) as HTMLElement
       fireEvent.click(removeButton)
 
-      expect(window.confirm).toHaveBeenCalledWith("Delete this task?")
-      expect(onRemoveTask).not.toHaveBeenCalled()
-      expect(onUpdate).not.toHaveBeenCalled()
+      expect(onRemoveTask).toHaveBeenCalled()
     })
   })
 
@@ -206,7 +198,7 @@ describe("Task", () => {
       fireEvent.change(titleInput, { target: { value: "Edited title" } })
 
       const pinButton = document.querySelector(
-        "[data-tooltip-content='Pin task']"
+        "[data-tooltip-content='Pin task (P)']"
       ) as HTMLElement
       fireEvent.click(pinButton)
 
@@ -226,7 +218,7 @@ describe("Task", () => {
       )
 
       const unpinButton = document.querySelector(
-        "[data-tooltip-content='Unpin task']"
+        "[data-tooltip-content='Unpin task (P)']"
       ) as HTMLElement
       fireEvent.click(unpinButton)
 
@@ -247,7 +239,7 @@ describe("Task", () => {
       })
 
       const moveButton = document.querySelector(
-        "[data-tooltip-content='Move to today']"
+        "[data-tooltip-content='Move to today (M)']"
       ) as HTMLElement
       fireEvent.click(moveButton)
 
@@ -265,7 +257,7 @@ describe("Task", () => {
       const { onUpdate } = renderTask({ pinned: false }, { active: true })
 
       const pinButton = document.querySelector(
-        "[data-tooltip-content='Pin task']"
+        "[data-tooltip-content='Pin task (P)']"
       ) as HTMLElement
       fireEvent.click(pinButton)
 

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -121,9 +121,30 @@ const Task: React.FC<Props> = ({
       }
     }
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>
+  ) => {
     if (event.key === "Enter" && event.metaKey) {
       onDeselect()
+    }
+    if (event.key === "Escape") {
+      onDeselect()
+    }
+
+    const target = event.target as HTMLElement
+    const isTyping = ["TEXTAREA", "INPUT"].includes(target.tagName)
+    if (isTyping) return
+
+    if (event.key === "p" && state) {
+      const updated = { ...state, pinned: !Boolean(state.pinned) }
+      setState(updated)
+      onUpdate(updated)
+    }
+    if (event.key === "x") {
+      onRemoveTask(state ?? task)
+    }
+    if (event.key === "m" && onMoveToToday) {
+      onMoveToToday(state ?? task)
     }
   }
 
@@ -318,7 +339,7 @@ const Task: React.FC<Props> = ({
           {onMoveToToday && (
             <div
               data-tooltip-id="tooltip"
-              data-tooltip-content="Move to today"
+              data-tooltip-content="Move to today (M)"
               className="remove-icon"
               onClick={preventDefault(() => {
                 onMoveToToday(state ?? task)
@@ -331,7 +352,9 @@ const Task: React.FC<Props> = ({
           {canPin && (
             <div
               data-tooltip-id="tooltip"
-              data-tooltip-content={state?.pinned ? "Unpin task" : "Pin task"}
+              data-tooltip-content={
+                state?.pinned ? "Unpin task (P)" : "Pin task (P)"
+              }
               className={cx("remove-icon", { active: state?.pinned })}
               style={state?.pinned ? { color: "#93c5fd" } : undefined}
               onClick={preventDefault(() => {
@@ -406,14 +429,9 @@ const Task: React.FC<Props> = ({
 
           <span
             className="remove-icon p-0! max-w-0 opacity-0 overflow-hidden transition-all duration-200 group-hover:max-w-[40px] group-hover:px-[10px]! group-hover:opacity-100"
-            onClick={() => {
-              if (
-                settings.confirmBeforeDelete &&
-                !window.confirm("Delete this task?")
-              )
-                return
-              onRemoveTask(task)
-            }}
+            data-tooltip-id="tooltip"
+            data-tooltip-content="Delete (X)"
+            onClick={() => onRemoveTask(state ?? task)}
           >
             <CrossIcon />
           </span>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import Portal from "./Portal"
+
+interface ToastProps {
+  message: string
+  action?: { label: string; onClick: () => void }
+  duration?: number
+  onDismiss: () => void
+}
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  action,
+  duration = 5000,
+  onDismiss
+}) => {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, duration)
+    return () => clearTimeout(timer)
+  }, [duration, onDismiss])
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        <motion.div
+          key="toast"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.2 }}
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-slate-800 dark:bg-navy-700 text-white text-sm rounded-lg px-4 py-3 shadow-lg"
+        >
+          <span>{message}</span>
+          {action && (
+            <button
+              className="no-style font-semibold text-blue-300 hover:text-blue-200"
+              onClick={action.onClick}
+            >
+              {action.label}
+            </button>
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </Portal>
+  )
+}
+
+export default Toast

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -24,6 +24,7 @@ import MobileDrawer from "./MobileDrawer"
 import Settings from "./Settings"
 import { useSettings } from "../context/SettingsContext"
 import useResize from "../hooks/useResize"
+import Toast from "./Toast"
 
 function Title({ children }: PropsWithChildren) {
   return (
@@ -118,8 +119,35 @@ const Todo: React.FC = ({}) => {
   )
 
   const handleUpdateTask = useAction<Task>(updateTask)
-  const handleRemoveTask = useAction<Task>(removeTask)
+  const doRemoveTask = useAction<Task>(removeTask)
   const handleMoveToToday = useAction<Task>(moveToToday)
+
+  const [pendingDelete, setPendingDelete] = useState<Task | null>(null)
+  const deleteTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
+
+  const handleRemoveTask = useCallback(
+    (task: Task) => {
+      setPendingDelete(task)
+      deleteTimerRef.current = setTimeout(() => {
+        doRemoveTask(task)
+        setPendingDelete(null)
+      }, 5000)
+    },
+    [doRemoveTask]
+  )
+
+  const handleUndoDelete = useCallback(() => {
+    clearTimeout(deleteTimerRef.current)
+    setPendingDelete(null)
+  }, [])
+
+  const commitDelete = useCallback(() => {
+    if (pendingDelete) {
+      clearTimeout(deleteTimerRef.current)
+      doRemoveTask(pendingDelete)
+      setPendingDelete(null)
+    }
+  }, [pendingDelete, doRemoveTask])
 
   // Label callbacks
   const handleAddLabel = useAction<LabelType>(addLabel)
@@ -141,6 +169,8 @@ const Todo: React.FC = ({}) => {
       setSidebarWidth(Math.max(MIN_SIDEBAR_WIDTH, sidebar.width))
     }
   }, [sidebar.width])
+
+  const [searchQuery, setSearchQuery] = useState("")
 
   const { handleMouseDown: handleResizeMouseDown } = useResize({
     minWidth: 0.2,
@@ -172,14 +202,21 @@ const Todo: React.FC = ({}) => {
 
   const [drawerOpen, setDrawerOpen] = useState(false)
 
-  const completedContent = !completed.collapsed && (
-    <div
+  const widthTransition = { duration: 0.3, ease: [0.4, 0, 0.2, 1] }
+
+  const completedContent = (
+    <motion.div
       className="flex-col bg-slate-50/60 dark:bg-navy-800 hidden md:flex"
+      animate={{
+        width: completed.collapsed
+          ? "0%"
+          : `${(isDesktop ? grid.completed[1] : 0) * 100}%`,
+        padding: completed.collapsed ? 0 : 32
+      }}
+      transition={widthTransition}
       style={{
-        width: `${(isDesktop ? grid.completed[1] : 0) * 100}%`,
         height: fullHeight,
-        padding: 32,
-        paddingTop: 8,
+        paddingTop: completed.collapsed ? 0 : 8,
         overflow: "hidden"
       }}
     >
@@ -223,7 +260,7 @@ const Todo: React.FC = ({}) => {
           <div className="w-full overflow-y-auto flex-1 min-h-0">
             <div>
               <List
-                tasks={yesterdaysTasks}
+                tasks={yesterdaysTasks.filter(t => t.id !== pendingDelete?.id)}
                 labels={labelsById}
                 filters={data.filters}
                 collapseCompleted={true}
@@ -248,7 +285,7 @@ const Todo: React.FC = ({}) => {
           </div>
         </motion.div>
       </AnimatePresence>
-    </div>
+    </motion.div>
   )
 
   return (
@@ -288,12 +325,15 @@ const Todo: React.FC = ({}) => {
             </div>
           )}
 
-          <div
+          <motion.div
             className="flex flex-col"
+            animate={{
+              width: `${grid.focus[isDesktop ? Math.min(grid.focus.length - 1, breakpoint) : 0] * 100}%`
+            }}
+            transition={widthTransition}
             style={{
-              width: `${grid.focus[isDesktop ? Math.min(grid.focus.length - 1, breakpoint) : 0] * 100}%`,
-              paddingLeft: isDesktop ? 16 : 16,
-              paddingRight: isDesktop ? 16 : 16,
+              paddingLeft: 16,
+              paddingRight: 16,
               paddingTop: 8,
               paddingBottom: isDesktop ? 32 : 16,
               height: fullHeight
@@ -321,9 +361,34 @@ const Todo: React.FC = ({}) => {
               </div>
             )}
 
+            {todaysTasks.length > 0 && (
+              <div className="mb-3">
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === "Escape") setSearchQuery("")
+                  }}
+                  placeholder="Search tasks..."
+                  className="w-full text-sm border border-slate-200 dark:border-navy-700 rounded-lg px-3 py-2 outline-none placeholder-slate-400 dark:placeholder-navy-500 dark:text-navy-100"
+                  style={{ background: "transparent" }}
+                />
+              </div>
+            )}
+
             <div className="w-full flex-2 overflow-y-scroll">
               <List
-                tasks={todaysTasks}
+                tasks={todaysTasks
+                  .filter(t => t.id !== pendingDelete?.id)
+                  .filter(t => {
+                    if (!searchQuery) return true
+                    const q = searchQuery.toLowerCase()
+                    return (
+                      t.title.toLowerCase().includes(q) ||
+                      t.description?.toLowerCase().includes(q)
+                    )
+                  })}
                 labels={labelsById}
                 filters={data.filters}
                 hideCompleted={settings.moveCompletedToYesterday}
@@ -331,6 +396,9 @@ const Todo: React.FC = ({}) => {
                 onUpdateTask={handleUpdateTask}
                 onRemoveTask={handleRemoveTask}
                 onMarkAsComplete={markAsComplete}
+                onReorder={reordered => {
+                  reordered.forEach(t => handleUpdateTask(t))
+                }}
               />
             </div>
 
@@ -342,7 +410,7 @@ const Todo: React.FC = ({}) => {
                 onAdd={task => handleAddTask(task, today())}
               />
             </div>
-          </div>
+          </motion.div>
 
           {isDesktop && (
             <div
@@ -389,13 +457,18 @@ const Todo: React.FC = ({}) => {
               </div>
             </div>
           )}
-          {isDesktop && !sidebar.collapsed && (
-            <div
+          {isDesktop && (
+            <motion.div
               className="bg-slate-50/60 dark:bg-navy-800 flex flex-col"
+              animate={{
+                width: sidebar.collapsed
+                  ? "0%"
+                  : `${activeSidebarWidth * 100}%`,
+                padding: sidebar.collapsed ? 0 : 32
+              }}
+              transition={widthTransition}
               style={{
-                width: `${activeSidebarWidth * 100}%`,
-                padding: 32,
-                paddingTop: 8,
+                paddingTop: sidebar.collapsed ? 0 : 8,
                 height: fullHeight,
                 overflow: "hidden"
               }}
@@ -436,7 +509,7 @@ const Todo: React.FC = ({}) => {
                   </div>
                 </motion.div>
               </AnimatePresence>
-            </div>
+            </motion.div>
           )}
         </div>
       </main>
@@ -468,6 +541,14 @@ const Todo: React.FC = ({}) => {
             </div>
           </div>
         </MobileDrawer>
+      )}
+
+      {pendingDelete && (
+        <Toast
+          message={`"${pendingDelete.title}" deleted`}
+          action={{ label: "Undo", onClick: handleUndoDelete }}
+          onDismiss={commitDelete}
+        />
       )}
     </>
   )

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -5,7 +5,6 @@ const STORAGE_KEY = "what-todo-settings"
 
 const defaultSettings: Settings = {
   autoCollapseCompleted: true,
-  confirmBeforeDelete: false,
   moveCompletedToYesterday: false,
   defaultLabelId: null,
   sortBy: "pinned",

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,33 @@
+import { useEffect, RefObject } from "react"
+
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
+export default function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean
+) {
+  useEffect(() => {
+    if (!active || !ref.current) return
+    const el = ref.current
+    const focusable = el.querySelectorAll<HTMLElement>(FOCUSABLE)
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+
+    first?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || focusable.length === 0) return
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    el.addEventListener("keydown", handleKeyDown)
+    return () => el.removeEventListener("keydown", handleKeyDown)
+  }, [active, ref])
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,6 +23,7 @@ export interface Task {
   // Fields after release #1
   pinned?: boolean
   completed_at?: string | undefined
+  order?: number
 }
 
 export type Section = "completed" | "focus" | "sidebar"
@@ -54,7 +55,6 @@ export type LabelStyle = "circle" | "pill"
 
 export interface Settings {
   autoCollapseCompleted: boolean
-  confirmBeforeDelete: boolean
   moveCompletedToYesterday: boolean
   defaultLabelId: string | null
   sortBy: SortBy


### PR DESCRIPTION
Quick wins:
  1. Empty state — "Nothing to do — enjoy your day!" when no tasks
  2. Escape to deselect — Escape key closes active task editing
  3. Mobile drawer close button — X icon in drawer header + Escape key
  4. Undo delete — replaced window.confirm with toast + 5s undo window, removed confirmBeforeDelete setting
  5. Keyboard shortcuts — P (pin), X (delete), M (move to today) when task is active; hints in tooltips

  Medium effort:
  6. Search tasks — search input above task list, filters by title/description, Escape clears
  7. Drag to reorder — framer-motion Reorder.Group + order field on tasks
  8. Focus trap — Tab cycles within mobile drawer, Escape closes
  9. Smooth section transitions — completed/focus/sidebar widths animate with motion.div
  10. Import modal — replaced window.prompt with a proper modal (textarea + validation + Cancel/Import