### PR TITLE
iOS fixes

### DIFF
--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -61,7 +61,10 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
               transition={{ type: "spring", damping: 30, stiffness: 300 }}
               className="fixed top-0 right-0 bottom-0 w-4/5 max-w-sm z-50 bg-white dark:bg-navy-900 shadow-xl flex flex-col"
             >
-              <div className="flex items-center justify-end p-4 pb-0">
+              <div
+                className="flex items-center justify-end p-4 pb-0"
+                style={{ paddingTop: "max(16px, env(safe-area-inset-top))" }}
+              >
                 <button
                   className="no-style text-slate-500 dark:text-navy-400"
                   onClick={onClose}

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -187,7 +187,7 @@ const Todo: React.FC = ({}) => {
 
   const activeSidebarWidth = sidebar.collapsed ? 0 : sidebarWidth
 
-  const fullHeight = "calc(100dvh - 66px)"
+  const fullHeight = "calc(100dvh - 66px - env(safe-area-inset-bottom, 0px))"
 
   const isDesktop =
     breakpoint != Breakpoints.MOBILE && breakpoint != Breakpoints.TABLET


### PR DESCRIPTION
On iOS standalone mode (PWA), the drawer close button was hidden behind the notch/status bar and the task input at the bottom was partially clipped by the home indicator. Added `env(safe-area-inset-top)` padding to the drawer header and subtracted `env(safe-area-inset-bottom)` from the main layout height calculation.

Test on an iOS device with a notch — open the drawer and verify the X is reachable, and check the bottom input is fully visible above the home indicator.