### PR TITLE
Mobile drawer alignment

### DIFF
--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -8,6 +8,7 @@ import useFocusTrap from "../hooks/useFocusTrap"
 interface MobileDrawerProps {
   open: boolean
   onClose: () => void
+  title?: React.ReactNode
   children: React.ReactNode
   footer?: React.ReactNode
 }
@@ -15,6 +16,7 @@ interface MobileDrawerProps {
 const MobileDrawer: React.FC<MobileDrawerProps> = ({
   open,
   onClose,
+  title,
   children,
   footer
 }) => {
@@ -62,9 +64,10 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
               className="fixed top-0 right-0 bottom-0 w-4/5 max-w-sm z-50 bg-white dark:bg-navy-900 shadow-xl flex flex-col"
             >
               <div
-                className="flex items-center justify-end p-4 pb-0"
-                style={{ paddingTop: "max(16px, env(safe-area-inset-top))" }}
+                className="flex items-center justify-between px-4"
+                style={{ paddingTop: "max(8px, env(safe-area-inset-top))" }}
               >
+                {title || <span />}
                 <button
                   className="no-style text-slate-500 dark:text-navy-400"
                   onClick={onClose}
@@ -73,7 +76,7 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
                   <CrossIcon fontSize={22} />
                 </button>
               </div>
-              <div className="flex-1 overflow-y-auto p-4 pt-2 min-h-0">
+              <div className="flex-1 overflow-y-auto p-4 pt-0 min-h-0">
                 {children}
               </div>
               {footer && <div className="p-4">{footer}</div>}

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -569,23 +569,46 @@ const Todo: React.FC = ({}) => {
         <MobileDrawer
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
+          title={
+            <button
+              type="button"
+              className="no-style flex items-center cursor-pointer"
+              onClick={() => setLabelsCollapsed(!labelsCollapsed)}
+              aria-expanded={!labelsCollapsed}
+            >
+              <h1 className="text-4xl text-slate-300 dark:text-navy-500 font-bold">
+                Labels
+              </h1>
+              <span className="ml-1" aria-hidden="true">
+                {labelsCollapsed ? (
+                  <ChevronDown
+                    className="text-slate-300 dark:text-navy-500"
+                    style={{ verticalAlign: "middle" }}
+                  />
+                ) : (
+                  <ChevronUp
+                    className="text-slate-300 dark:text-navy-500"
+                    style={{ verticalAlign: "middle" }}
+                  />
+                )}
+              </span>
+            </button>
+          }
           footer={<Footer />}
         >
-          <div className="pb-1">
-            <Title>Labels</Title>
-          </div>
-
           <div className="flex-1 overflow-y-auto pb-2">
-            <Labels
-              labels={data.labels}
-              limit={15}
-              colors={colors}
-              filters={data.filters}
-              onFilter={updateFilters}
-              onAddLabel={handleAddLabel}
-              onUpdateLabel={handleUpdateLabel}
-              onRemoveLabel={handleRemoveLabel}
-            />
+            <Collapse open={!labelsCollapsed}>
+              <Labels
+                labels={data.labels}
+                limit={15}
+                colors={colors}
+                filters={data.filters}
+                onFilter={updateFilters}
+                onAddLabel={handleAddLabel}
+                onUpdateLabel={handleUpdateLabel}
+                onRemoveLabel={handleRemoveLabel}
+              />
+            </Collapse>
 
             <div className="mt-4">
               <Settings labels={data.labels} />


### PR DESCRIPTION
The mobile drawer had too much whitespace above the Labels heading — the close button and title were stacked vertically with generous padding. Moved the Labels heading inline with the X button by adding a `title` prop to MobileDrawer and rendering them in the same flex row. Also added the same collapse toggle (chevron + Collapse component) to the mobile drawer Labels section so it matches the desktop sidebar behavior. Tightened the header padding to respect safe area insets without wasting vertical space.

Open the app on a mobile viewport and check the drawer layout — Labels heading should sit on the same line as the X, and tapping "Labels" should collapse/expand the label list.