### PR TITLE
fix sequencing of events

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test"
-import { seed, makeData } from "./helpers"
+import { seed, makeData, dataWithTasks } from "./helpers"
 
 test("full app workflow", async ({ page }) => {
   await seed(page, makeData())
@@ -225,12 +225,12 @@ test("full app workflow", async ({ page }) => {
     await page.keyboard.press("Escape")
   })
 
-  await test.step("toggle show task count setting", async () => {
-    await page.getByLabel("Show task count").click()
+  await test.step("task count is always visible", async () => {
     await expect(page.locator("header span.rounded-full")).toBeVisible()
   })
 
   await test.step("toggle compact mode", async () => {
+    await page.getByLabel("Expand section").last().click()
     await page.getByLabel("Compact mode").click()
     // Verify reduced spacing on task cards
     const card = page
@@ -412,11 +412,10 @@ test("mobile", async ({ page }) => {
     await expect(page.getByRole("dialog")).toBeVisible()
     await expect(page.getByRole("heading", { name: "Labels" })).toBeVisible()
     await expect(page.getByText("Settings")).toBeVisible()
-    await expect(page.getByLabel("Show task count")).toBeVisible()
+    await expect(page.getByLabel("Compact mode")).toBeVisible()
   })
 
-  await test.step("toggle setting in drawer persists", async () => {
-    await page.getByLabel("Show task count").click()
+  await test.step("task count is always visible in mobile", async () => {
     await page.getByLabel("Close menu").click()
     await expect(page.locator("header span.rounded-full")).toBeVisible()
   })
@@ -437,5 +436,72 @@ test("mobile", async ({ page }) => {
     await expect(page.getByRole("dialog")).toBeVisible()
     await page.keyboard.press("Escape")
     await expect(page.getByRole("dialog")).toBeHidden()
+  })
+})
+
+test("sequential deletes and completes", async ({ page }) => {
+  const tasks = [
+    { title: "Task A" },
+    { title: "Task B" },
+    { title: "Task C" },
+    { title: "Task D" },
+    { title: "Task E" }
+  ]
+  await seed(page, dataWithTasks(tasks))
+  await page.goto("/")
+
+  const card = (name: string) =>
+    page.locator("[role='button']").filter({ hasText: name })
+
+  await test.step("all seeded tasks are visible", async () => {
+    for (const t of tasks) {
+      await expect(page.getByText(t.title)).toBeVisible()
+    }
+  })
+
+  await test.step("deleting multiple tasks in sequence removes them all", async () => {
+    await card("Task A").hover()
+    await card("Task A").getByLabel("Delete task").click()
+    await card("Task B").hover()
+    await card("Task B").getByLabel("Delete task").click()
+    await card("Task C").hover()
+    await card("Task C").getByLabel("Delete task").click()
+
+    await expect(card("Task A")).toBeHidden()
+    await expect(card("Task B")).toBeHidden()
+    await expect(card("Task C")).toBeHidden()
+    await expect(card("Task D")).toBeVisible()
+    await expect(card("Task E")).toBeVisible()
+  })
+
+  await test.step("deleted tasks are committed to storage after undo window", async () => {
+    await page.getByRole("alert").waitFor({ state: "hidden", timeout: 7000 })
+    await expect
+      .poll(async () => {
+        const data = await page.evaluate(() =>
+          JSON.parse(localStorage.getItem("what-todo") ?? "{}")
+        )
+        const allTasks = Object.values(data.tasks).flat() as any[]
+        return allTasks.map((t: any) => t.title).sort()
+      })
+      .toEqual(["Task D", "Task E"])
+  })
+
+  await test.step("completing multiple tasks in sequence persists them all", async () => {
+    await card("Task D").locator(".checkbox label").click()
+    await card("Task E").locator(".checkbox label").click()
+
+    await expect
+      .poll(
+        async () => {
+          const data = await page.evaluate(() =>
+            JSON.parse(localStorage.getItem("what-todo") ?? "{}")
+          )
+          const allTasks = Object.values(data.tasks).flat() as any[]
+          return allTasks.every((t: any) => t.completed)
+        },
+        { timeout: 10000 }
+      )
+      .toBe(true)
   })
 })

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -96,14 +96,6 @@ export default function Settings({ labels }: SettingsProps) {
 
       <Collapse open={!collapsed}>
         <div className="divide-y divide-slate-200 dark:divide-navy-700">
-          <SettingRow label="Show task count">
-            <Toggle
-              label="Show task count"
-              checked={settings.showTaskCount}
-              onChange={v => updateSetting("showTaskCount", v)}
-            />
-          </SettingRow>
-
           <SettingRow label="Compact mode">
             <Toggle
               label="Compact mode"

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -129,7 +129,7 @@ const Task: React.FC<Props> = ({
     const isTyping = ["TEXTAREA", "INPUT"].includes(target.tagName)
     if (isTyping) return
 
-    if (event.key === "p" && state) {
+    if (event.key === "p" && state && !state.completed) {
       const updated = { ...state, pinned: !Boolean(state.pinned) }
       setState(updated)
       onUpdate(updated)
@@ -166,7 +166,11 @@ const Task: React.FC<Props> = ({
 
   const handleSelect = useCallback(() => {
     if (state) {
-      const updated = { ...state, completed: !state.completed }
+      const updated = {
+        ...state,
+        completed: !state.completed,
+        pinned: state.completed ? state.pinned : false
+      }
       setState(updated)
 
       if (state.completed) {
@@ -215,7 +219,7 @@ const Task: React.FC<Props> = ({
           active
             ? "bg-slate-100 dark:bg-navy-700"
             : "bg-slate-50 dark:bg-navy-800",
-          state?.pinned
+          state?.pinned && !state?.completed
             ? "border-blue-300 dark:border-blue-500/50"
             : "border-transparent",
           {
@@ -352,7 +356,7 @@ const Task: React.FC<Props> = ({
             </button>
           )}
 
-          {canPin && (
+          {canPin && !state?.completed && (
             <button
               type="button"
               data-tooltip-id="tooltip"

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -122,13 +122,17 @@ const Todo: React.FC = ({}) => {
         doRemoveTask(task)
         return
       }
+      if (pendingDelete) {
+        clearTimeout(deleteTimerRef.current)
+        doRemoveTask(pendingDelete)
+      }
       setPendingDelete(task)
       deleteTimerRef.current = setTimeout(() => {
         doRemoveTask(task)
         setPendingDelete(null)
       }, 5000)
     },
-    [doRemoveTask, settings.undoOnDelete]
+    [doRemoveTask, settings.undoOnDelete, pendingDelete]
   )
 
   const handleUndoDelete = useCallback(() => {
@@ -219,11 +223,7 @@ const Todo: React.FC = ({}) => {
         onMenuClick={
           !isDesktop ? () => setDrawerOpen(prev => !prev) : undefined
         }
-        taskCount={
-          settings.showTaskCount
-            ? todaysTasks.filter(t => !t.completed).length
-            : undefined
-        }
+        taskCount={todaysTasks.filter(t => !t.completed).length}
         date={formatDateHeading(todayDateStr)}
       />
       <main>

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -6,7 +6,6 @@ const STORAGE_KEY = "what-todo-settings"
 const defaultSettings: Settings = {
   defaultLabelId: null,
   sortBy: "pinned",
-  showTaskCount: false,
   compactMode: false,
   undoOnDelete: true,
   labelStyle: "circle"

--- a/src/context/StorageContext.tsx
+++ b/src/context/StorageContext.tsx
@@ -60,21 +60,25 @@ function StorageProvider({ children }: PropsWithChildren<unknown>): any {
     })
   }
 
+  const dataRef = React.useRef(data)
+  dataRef.current = data
+
   function useAction<A, B = any>(
     fn: (data: Data, dataType: A, otherType?: B) => Data
   ) {
     return useCallback(
       (dataType: A, otherType?: B) => {
-        const newData = fn.call(storage, data, dataType, otherType)
+        const newData = fn.call(storage, dataRef.current, dataType, otherType)
 
         if (typeof newData === "undefined") {
           throw new Error("Trying to update storage data with undefined")
         }
 
+        dataRef.current = newData
         setData(newData)
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [fn, data]
+
+      [fn]
     )
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,6 @@ export type LabelStyle = "circle" | "pill"
 export interface Settings {
   defaultLabelId: string | null
   sortBy: SortBy
-  showTaskCount: boolean
   compactMode: boolean
   undoOnDelete: boolean
   labelStyle: LabelStyle


### PR DESCRIPTION
Rapid sequential deletes and completions were broken — deleting multiple todos would cause earlier ones to reappear, and completing multiple in a row would silently drop completions. Both stem from stale closures: `pendingDelete` was a single `Task | null` that got overwritten on each new delete, and `useAction` closed over `data` directly so any callback fired from a `setTimeout` operated on stale state. Fixed by committing the previous pending delete before tracking a new one, and switching `useAction` to use a `dataRef` so all mutations always read the latest state. Also: completing a task now unpins it and hides the pin UI, and the "show task count" setting was removed (always on).

Rapidly delete and complete several todos in sequence — none should reappear or lose their state. Check that pinned tasks get unpinned on completion and the pin button disappears. Task count badge should always be visible with no setting to toggle it.