### PR TITLE
Fix typecheck

### DIFF
--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -184,12 +184,6 @@ class StorageManager {
     return JSON.parse(JSON.stringify(data))
   }
 
-  private clearAllData(): Data {
-    this.sync(this.defaultData, "CLEAR_DATA")
-
-    return this.defaultData
-  }
-
   private async clearLegacyData() {
     console.log("Clearing all legacy sync storage data")
     try {
@@ -206,7 +200,7 @@ class StorageManager {
     const unsynced = this.syncQueue.length
 
     while (this.syncQueue.length) {
-      this.syncQueue.shift()(data)
+      this.syncQueue.shift()!(data)
     }
     if (unsynced) {
       console.log(`>>> SYNC_QUEUE_CLEARED (${unsynced})`)
@@ -313,12 +307,8 @@ class StorageManager {
     this.subscriptions = this.subscriptions.filter(x => x !== fn)
   }
 
-  async getData(): Promise<{
-    data: Data
-    usage: string
-    quota: string
-  }> {
-    let parsedData: Data
+  async getData(): Promise<{ data: Data }> {
+    let parsedData: Data = this.defaultData
 
     this.setBusyState()
     console.groupCollapsed("GET_STORAGE_DATA")
@@ -357,6 +347,7 @@ class StorageManager {
       }
     } catch (error) {
       console.error(error)
+      return { data: parsedData }
     } finally {
       console.timeEnd("getData()")
       console.groupEnd()

--- a/src/color-palette.ts
+++ b/src/color-palette.ts
@@ -1,13 +1,17 @@
 export interface Color {
   name?: string
   backgroundColor: string
-  foregroundColor
+  foregroundColor: string
 }
 
 const BLACK = "#000000"
 const WHITE = "#ffffff"
 
-const createColor = (name, backgroundColor, foregroundColor = WHITE): Color => {
+const createColor = (
+  name: string,
+  backgroundColor: string,
+  foregroundColor = WHITE
+): Color => {
   return {
     name,
     backgroundColor,

--- a/src/components/Animate.tsx
+++ b/src/components/Animate.tsx
@@ -1,6 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion"
-
-import React from "react"
+import { AnimatePresence, motion, type Easing } from "framer-motion"
 
 const variants = {
   open: { height: "auto", opacity: 1 },
@@ -11,12 +9,18 @@ export default function Animate({
   children,
   active,
   duration = 0.2,
-  ease = [0.645, 0.045, 0.355, 1],
+  ease = [0.645, 0.045, 0.355, 1] as Easing,
   skipInitial = false
+}: {
+  children: React.ReactNode
+  active: unknown
+  duration?: number
+  ease?: Easing
+  skipInitial?: boolean
 }) {
   return (
     <AnimatePresence initial={!skipInitial}>
-      {active && (
+      {active ? (
         <motion.div
           initial="closed"
           animate="open"
@@ -27,7 +31,7 @@ export default function Animate({
         >
           {children}
         </motion.div>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -36,9 +36,7 @@ const ColorPicker: React.FC<Props> = ({
 
   return (
     <div>
-      {React.cloneElement(children, {
-        ref: childRef
-      })}
+      <div ref={childRef}>{children}</div>
 
       {visible && (
         <Portal>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,13 +24,10 @@ const Footer: React.FC = () => {
   const { darkMode, toggleDarkMode } = useDarkMode()
   const dataStr =
     "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(data))
-  const downloadLinkRef = React.useRef()
+  const downloadLinkRef = React.useRef<HTMLAnchorElement>(null)
 
   const downloadJSON = React.useCallback(() => {
-    if (downloadLinkRef && downloadLinkRef.current) {
-      // @ts-ignore
-      downloadLinkRef.current.click()
-    }
+    downloadLinkRef.current?.click()
   }, [])
 
   const [importOpen, setImportOpen] = React.useState(false)

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react"
+import { useCallback, useRef } from "react"
 import cx from "classnames"
 import MenuIcon from "@meronex/icons/fi/FiMenu"
 
@@ -47,7 +47,7 @@ function Header({
   date?: string
 }) {
   const tapCount = useRef(0)
-  const tapTimer = useRef<ReturnType<typeof setTimeout>>()
+  const tapTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   const handleLogoTap = useCallback(() => {
     tapCount.current++

--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -39,10 +39,13 @@ const Labels: React.FC<Props> = ({
   const [newLabel, setNewLabel] = React.useState<IntermediateLabel>()
 
   React.useEffect(() => {
-    const labelsById = labels.reduce((state, label) => {
-      state[label.id] = label
-      return state
-    }, {})
+    const labelsById = labels.reduce(
+      (state, label) => {
+        state[label.id] = label
+        return state
+      },
+      {} as Record<string, LabelType>
+    )
 
     setControlledLabels(labelsById)
   }, [labels])
@@ -58,14 +61,14 @@ const Labels: React.FC<Props> = ({
   }, [colors, labels])
 
   const handleSave = React.useCallback(() => {
-    if (newLabel.title.trim().length > 0) {
+    if (newLabel && newLabel.title.trim().length > 0) {
       onAddLabel(newLabel)
     }
     setNewLabel(undefined)
   }, [newLabel, onAddLabel])
 
   const handleChangeTitle = React.useCallback(
-    (id, event) => {
+    (id: string, event: React.ChangeEvent<HTMLInputElement>) => {
       const newLabel = {
         ...controlledLabels[id],
         title: event.target.value
@@ -81,7 +84,7 @@ const Labels: React.FC<Props> = ({
   )
 
   const handleKeyPress = React.useCallback(
-    event => {
+    (event: React.KeyboardEvent) => {
       if (event.key === "Enter") {
         handleSave()
       }
@@ -90,7 +93,7 @@ const Labels: React.FC<Props> = ({
   )
 
   const handleColorChange = React.useCallback(
-    (color: Color, label) => {
+    (color: Color, label: LabelType) => {
       // do something
       const newLabel = {
         ...label,
@@ -109,7 +112,7 @@ const Labels: React.FC<Props> = ({
   )
 
   const handleBlur = React.useCallback(
-    id => {
+    (id: string) => {
       onUpdateLabel(controlledLabels[id])
     },
     [controlledLabels, onUpdateLabel]

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -101,7 +101,7 @@ const List: React.FC<Props> = ({
   onReorder
 }) => {
   const { settings } = useSettings()
-  const selectedRef = useRef<any>()
+  const selectedRef = useRef<HTMLDivElement>(null)
   const [selected, setSelected] = React.useState<TaskType["id"] | undefined>()
   const [collapsed, setCollapsed] = React.useState(collapseCompleted)
   const filteredTasks = getFilteredTasks(tasks, filters)
@@ -131,8 +131,8 @@ const List: React.FC<Props> = ({
       )
     }
 
-    const ap = typeof a.pinned === "boolean" && +a.pinned
-    const bp = typeof b.pinned === "boolean" && +b.pinned
+    const ap = typeof a.pinned === "boolean" ? +a.pinned : 0
+    const bp = typeof b.pinned === "boolean" ? +b.pinned : 0
     if (ap !== bp) return bp - ap
     const ao = a.order ?? Infinity
     const bo = b.order ?? Infinity

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -1,5 +1,10 @@
 // Types
-import type { Data, Task, Label as LabelType } from "../index.d"
+import type {
+  Data,
+  Task,
+  Label as LabelType,
+  IntermediateLabel
+} from "../index.d"
 import React, { PropsWithChildren, useCallback, useState } from "react"
 // utils
 import { formatDateHeading, today } from "../utils"
@@ -114,7 +119,9 @@ const Todo: React.FC = ({}) => {
   const handleMoveToToday = useAction<Task>(moveToToday)
 
   const [pendingDelete, setPendingDelete] = useState<Task | null>(null)
-  const deleteTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
+  const deleteTimerRef = React.useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined)
 
   const handleRemoveTask = useCallback(
     (task: Task) => {
@@ -149,7 +156,10 @@ const Todo: React.FC = ({}) => {
   }, [pendingDelete, doRemoveTask])
 
   // Label callbacks
-  const handleAddLabel = useAction<LabelType>(addLabel)
+  const handleAddLabel = useCallback(
+    (label: IntermediateLabel) => addLabel(label as LabelType),
+    [addLabel]
+  )
   const handleRemoveLabel = useAction<LabelType>(removeLabel)
   const handleUpdateLabel = useAction<LabelType>(updateLabel)
 

--- a/src/context/SettingsContext.spec.tsx
+++ b/src/context/SettingsContext.spec.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { render, fireEvent } from "@testing-library/react"
 import { SettingsProvider, useSettings } from "./SettingsContext"
-import React from "react"
 
 function TestConsumer() {
   const { settings, updateSetting } = useSettings()

--- a/src/decorators/sync.ts
+++ b/src/decorators/sync.ts
@@ -5,12 +5,16 @@ import StorageManager from "../StorageManager"
 export function sync() {
   return function (
     target: StorageManager,
-    propertyKey: string,
-    descriptor?: PropertyDescriptor
+    _propertyKey: string,
+    descriptor: PropertyDescriptor
   ): void {
     const orig = descriptor.value
 
-    descriptor.value = function (currentData: Data, ...args: any[]) {
+    descriptor.value = function (
+      this: StorageManager,
+      currentData: Data,
+      ...args: any[]
+    ) {
       if (target.busy) {
         this.syncQueue.push((newData: Data) =>
           orig.call(target, newData, ...args)

--- a/src/hooks/portal.tsx
+++ b/src/hooks/portal.tsx
@@ -5,7 +5,7 @@ function usePortal(): HTMLDivElement {
 
   React.useEffect(() => {
     const parentElem = document.querySelector("#portal")
-    parentElem.appendChild(el)
+    parentElem?.appendChild(el)
     return () => el.remove()
   }, [el])
 

--- a/src/hooks/useFocusTrap.spec.tsx
+++ b/src/hooks/useFocusTrap.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { render, fireEvent } from "@testing-library/react"
-import React, { useRef } from "react"
+import { useRef } from "react"
 import useFocusTrap from "./useFocusTrap"
 
 function TrapTest({ active }: { active: boolean }) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ const App = () => {
   )
 }
 
-const container = document.getElementById("app")
+const container = document.getElementById("app")!
 const root = createRoot(container)
 
 root.render(

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module "@meronex/icons/*" {
+  import { ComponentType } from "react"
+  const Icon: ComponentType<Record<string, unknown>>
+  export default Icon
+}


### PR DESCRIPTION
The new typecheck CI job surfaced ~40 pre-existing TypeScript errors. This fixes all of them: missing type annotations, untyped callback parameters, unused imports, incorrect ref initialization for React 19, a `cloneElement` ref hack replaced with a wrapper div, and dead code removal in StorageManager. Also adds `vite-env.d.ts` with Vite client types and a module declaration for `@meronex/icons`.

Run `pnpm typecheck`, `pnpm lint`, and `pnpm test` — all should pass clean.