### PR TITLE
Glow animation, sticky search, and scroll-to-new

### DIFF
--- a/src/components/Animate.tsx
+++ b/src/components/Animate.tsx
@@ -1,8 +1,8 @@
 import { AnimatePresence, motion, type Easing } from "framer-motion"
 
 const variants = {
-  open: { height: "auto", opacity: 1 },
-  closed: { height: 0, opacity: 0 }
+  open: { height: "auto", opacity: 1, overflow: "visible" as const },
+  closed: { height: 0, opacity: 0, overflow: "hidden" as const }
 }
 
 export default function Animate({
@@ -26,8 +26,11 @@ export default function Animate({
           animate="open"
           exit="closed"
           variants={variants}
-          transition={{ duration, ease }}
-          style={{ overflow: "hidden" }}
+          transition={{
+            duration,
+            ease,
+            overflow: { delay: duration }
+          }}
         >
           {children}
         </motion.div>

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -103,6 +103,19 @@ const Task: React.FC<Props> = ({
   const [state, setState] = React.useState<TaskType | undefined>(task)
   const descriptionURL = getDescriptionURL(state?.description)
   const [, setHovering] = React.useState<boolean>(false)
+  const [glowing, setGlowing] = React.useState(false)
+
+  React.useEffect(() => {
+    if (task.completed) return
+    const isNew = Date.now() - new Date(task.created_at).getTime() < 5000
+    if (isNew) {
+      setGlowing(true)
+      const timer = setTimeout(() => {
+        ref.current?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+      }, 200)
+      return () => clearTimeout(timer)
+    }
+  }, [task.completed, task.created_at])
 
   const handleChange =
     (field: keyof TaskType) =>
@@ -130,9 +143,11 @@ const Task: React.FC<Props> = ({
     if (isTyping) return
 
     if (event.key === "p" && state && !state.completed) {
-      const updated = { ...state, pinned: !Boolean(state.pinned) }
+      const pinning = !Boolean(state.pinned)
+      const updated = { ...state, pinned: pinning }
       setState(updated)
       onUpdate(updated)
+      if (pinning) setGlowing(true)
     }
     if (event.key === "x") {
       onRemoveTask(state ?? task)
@@ -214,7 +229,7 @@ const Task: React.FC<Props> = ({
         tabIndex={0}
         onKeyDown={handleKeyDown}
         className={cx(
-          "group flex items-start hover:bg-slate-100 dark:hover:bg-navy-700 rounded-xl px-3 overflow-hidden h-auto border-2 outline-none",
+          "group flex items-start hover:bg-slate-100 dark:hover:bg-navy-700 rounded-xl px-3 h-auto border-2 outline-none",
           compact ? "py-2 mb-1" : "py-4 mb-3",
           active
             ? "bg-slate-100 dark:bg-navy-700"
@@ -223,12 +238,14 @@ const Task: React.FC<Props> = ({
             ? "border-blue-300 dark:border-blue-500/50"
             : "border-transparent",
           {
-            ["cursor-pointer"]: !active
+            ["cursor-pointer"]: !active,
+            ["animate-glow"]: glowing
           }
         )}
         onClick={handlePress}
         onMouseEnter={() => setHovering(true)}
         onMouseLeave={() => setHovering(false)}
+        onAnimationEnd={() => setGlowing(false)}
       >
         <div className="mt-[2px] mr-3">
           <Checkbox
@@ -370,9 +387,11 @@ const Task: React.FC<Props> = ({
               style={state?.pinned ? { color: "#93c5fd" } : undefined}
               onClick={preventDefault(() => {
                 if (!state) return
-                const updated = { ...state, pinned: !Boolean(state.pinned) }
+                const pinning = !Boolean(state.pinned)
+                const updated = { ...state, pinned: pinning }
                 setState(updated)
                 onUpdate(updated)
+                if (pinning) setGlowing(true)
               })}
             >
               {state?.pinned ? <PinFilled /> : <Pin />}

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -520,7 +520,7 @@ const Todo: React.FC = ({}) => {
 
             <div className="flex-1 overflow-y-auto min-h-0 px-6 pt-4">
               {data.filters.length > 0 && (
-                <div className="my-2">
+                <div className="mb-4">
                   <small>Showing: </small>
                   {data.filters.map(id => (
                     <div className="inline mb-1 mr-1" key={id}>
@@ -537,7 +537,7 @@ const Todo: React.FC = ({}) => {
               )}
 
               {todaysTasks.length > 0 && (
-                <div className="mb-3 relative">
+                <div className="mb-3 relative sticky top-0 z-10 bg-white dark:bg-navy-900 pb-1">
                   <SearchIcon
                     className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 dark:text-navy-500"
                     fontSize={14}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -284,4 +284,14 @@
     from { width: 0; }
     to { width: calc(100% + 10px); }
   }
+
+  .animate-glow {
+    animation: glow 1.5s ease-out forwards;
+  }
+
+  @keyframes glow {
+    0% { box-shadow: -8px 0 16px -4px rgba(59, 130, 246, 0.4), 8px 0 16px -4px rgba(139, 92, 246, 0.4); }
+    20% { box-shadow: -8px 0 20px 0px rgba(59, 130, 246, 0.3), 8px 0 20px 0px rgba(139, 92, 246, 0.3); }
+    100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0), 0 0 0 0 rgba(139, 92, 246, 0); }
+  }
 }


### PR DESCRIPTION
Adds a fleeting blue-to-purple box-shadow glow that plays once when a task is newly created or pinned. New tasks also auto-scroll into view after the enter animation finishes. The Animate component now transitions overflow from hidden to visible so the glow isn't clipped. Also makes the search input sticky on scroll and tightens the filter label spacing.

Create a few tasks and scroll down, then add another — it should scroll up and glow. Pin a task to see the same glow. Scroll with tasks present to verify the search bar stays pinned.