### PR TITLE
Improve touch on mobile

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -23,6 +23,7 @@
   ::backdrop,
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
+    touch-action: manipulation;
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Mobile taps often require two taps because the browser waits 300ms for a potential double-tap-to-zoom gesture. Adding `touch-action: manipulation` globally disables that delay so all interactions respond on the first tap.

Test on a mobile device or with Chrome DevTools touch simulation — buttons, checkboxes, and task selection should all respond immediately to a single tap.