### PR TITLE
Improve touch

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -24,6 +24,16 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
     touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-touch-callout: none;
+  }
+
+  button,
+  [role="button"],
+  label,
+  .task,
+  .checkbox {
+    user-select: none;
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Mobile interactions feel janky — grey tap highlights flash on every touch, long-press triggers the iOS context menu (interfering with drag-to-reorder), and accidental text selection fires during taps. This adds `-webkit-tap-highlight-color: transparent` and `-webkit-touch-callout: none` globally, plus `user-select: none` on interactive elements (buttons, task cards, checkboxes, labels) while keeping textareas and descriptions selectable.

Test on mobile or with touch simulation — tap, long-press, and drag tasks without any visual artifacts or unintended selection.