### PR TITLE
Fix issue with incomplete tasks moving to completed

### DIFF
--- a/src/components/Task.spec.tsx
+++ b/src/components/Task.spec.tsx
@@ -347,6 +347,36 @@ describe("Task", () => {
     })
   })
 
+  describe("Checkbox click does not select task", () => {
+    it("does not call onSelect when checkbox is clicked on inactive task", () => {
+      const { onSelect } = renderTask()
+      const checkbox = document.querySelector(".checkbox label") as HTMLElement
+      fireEvent.click(checkbox)
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it("does not call onSelect when checkbox input is clicked", () => {
+      const { onSelect } = renderTask()
+      const input = document.querySelector(
+        "input[type='checkbox']"
+      ) as HTMLElement
+      fireEvent.click(input)
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it("calls onMarkAsComplete when checkbox is clicked", () => {
+      vi.useFakeTimers()
+      const { onMarkAsComplete } = renderTask()
+      const input = document.querySelector(
+        "input[type='checkbox']"
+      ) as HTMLElement
+      fireEvent.click(input)
+      vi.advanceTimersByTime(1500)
+      expect(onMarkAsComplete).toHaveBeenCalled()
+      vi.useRealTimers()
+    })
+  })
+
   describe("Mobile delete button visibility", () => {
     it("delete button has mobile-visible classes", () => {
       renderTask()

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -206,7 +206,9 @@ const Task: React.FC<Props> = ({
 
       const target = event.target as HTMLElement
 
+      const isCheckbox = target.closest(".checkbox")
       if (
+        !isCheckbox &&
         !["TEXTAREA"].includes(event.currentTarget.nodeName) &&
         !["INPUT", "svg"].includes(target.nodeName)
       ) {

--- a/src/components/Todo.spec.tsx
+++ b/src/components/Todo.spec.tsx
@@ -4,35 +4,44 @@ import Todo from "./Todo"
 import { SettingsProvider } from "../context/SettingsContext"
 import { DarkModeProvider } from "../context/DarkModeContext"
 
-const defaultData = {
-  tasks: {},
-  labels: [
-    { id: "l1", title: "Work", color: "#5352ed" },
-    { id: "l2", title: "Personal", color: "#ff7f50" }
-  ],
-  filters: [],
-  sections: {
-    completed: { collapsed: false },
-    focus: {},
-    sidebar: { collapsed: false }
+const yesterday = new Date(Date.now() - 86400000).toDateString()
+
+const mockMoveToToday = vi.fn()
+
+let testData: Record<string, any> = {}
+
+function makeDefaultData(overrides: Record<string, any> = {}) {
+  return {
+    tasks: {},
+    labels: [
+      { id: "l1", title: "Work", color: "#5352ed" },
+      { id: "l2", title: "Personal", color: "#ff7f50" }
+    ],
+    filters: [],
+    sections: {
+      completed: { collapsed: false },
+      focus: {},
+      sidebar: { collapsed: false }
+    },
+    ...overrides
   }
 }
 
 vi.mock("../context/StorageContext", () => ({
   useStorage: () => ({
-    data: defaultData,
+    data: testData,
     labelsById: {
       l1: { id: "l1", title: "Work", color: "#5352ed" },
       l2: { id: "l2", title: "Personal", color: "#ff7f50" }
     },
-    sections: defaultData.sections,
+    sections: testData.sections,
     storage: {},
     fetchData: vi.fn(),
     addTask: vi.fn(),
     updateTask: vi.fn(),
     removeTask: vi.fn(),
     markAsComplete: vi.fn(),
-    moveToToday: vi.fn(),
+    moveToToday: mockMoveToToday,
     addLabel: vi.fn(),
     updateLabel: vi.fn(),
     removeLabel: vi.fn(),
@@ -67,6 +76,8 @@ function renderTodo() {
 describe("Todo — curtain sidebar animation", () => {
   beforeEach(() => {
     localStorage.clear()
+    mockMoveToToday.mockClear()
+    testData = makeDefaultData()
   })
 
   it("always renders the completed section in the DOM", () => {
@@ -169,5 +180,99 @@ describe("Todo — curtain sidebar animation", () => {
     ) as HTMLElement
     expect(section).toBeTruthy()
     expect(section.style.pointerEvents).toBe("auto")
+  })
+})
+
+describe("Todo — older task migration", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockMoveToToday.mockClear()
+  })
+
+  it("moves uncompleted older tasks to today", () => {
+    testData = makeDefaultData({
+      tasks: {
+        [yesterday]: [
+          {
+            id: "old-1",
+            title: "Unfinished task",
+            completed: false,
+            created_at: new Date(yesterday).toISOString(),
+            labels: []
+          },
+          {
+            id: "old-2",
+            title: "Done task",
+            completed: true,
+            created_at: new Date(yesterday).toISOString(),
+            labels: []
+          }
+        ]
+      }
+    })
+
+    renderTodo()
+
+    expect(mockMoveToToday).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "old-1", completed: false })
+    )
+    expect(mockMoveToToday).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "old-2" })
+    )
+  })
+
+  it("does not move completed older tasks", () => {
+    testData = makeDefaultData({
+      tasks: {
+        [yesterday]: [
+          {
+            id: "old-done",
+            title: "Completed yesterday",
+            completed: true,
+            created_at: new Date(yesterday).toISOString(),
+            labels: []
+          }
+        ]
+      }
+    })
+
+    renderTodo()
+
+    expect(mockMoveToToday).not.toHaveBeenCalled()
+  })
+
+  it("completed sidebar only shows completed tasks", () => {
+    testData = makeDefaultData({
+      tasks: {
+        [yesterday]: [
+          {
+            id: "old-incomplete",
+            title: "Should not appear",
+            completed: false,
+            created_at: new Date(yesterday).toISOString(),
+            labels: []
+          },
+          {
+            id: "old-complete",
+            title: "Should appear in completed",
+            completed: true,
+            created_at: new Date(yesterday).toISOString(),
+            labels: []
+          }
+        ]
+      }
+    })
+
+    renderTodo()
+
+    const completedHeading = Array.from(document.querySelectorAll("h1")).find(
+      el => el.textContent === "Completed"
+    )
+    const completedSection = completedHeading?.closest(
+      "[style*='position: absolute']"
+    ) as HTMLElement
+
+    expect(completedSection).toBeTruthy()
+    expect(completedSection.textContent).not.toContain("Should not appear")
   })
 })

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -87,9 +87,9 @@ const Todo: React.FC = ({}) => {
   const todaysTasks = getTasksFor(todayDateStr)(data)
   const olderTasks = getOlderTasks(data)
 
-  // Move any pinned tasks to today
+  // Move any uncompleted older tasks to today
   olderTasks.map(task => {
-    if (task.pinned) {
+    if (!task.completed) {
       moveToToday(task)
     }
   })
@@ -303,7 +303,7 @@ const Todo: React.FC = ({}) => {
                     <div>
                       <List
                         tasks={olderTasks.filter(
-                          t => t.id !== pendingDelete?.id
+                          t => t.id !== pendingDelete?.id && t.completed
                         )}
                         labels={labelsById}
                         filters={data.filters}


### PR DESCRIPTION
Incomplete tasks from previous days were leaking into the "Completed" sidebar because `olderTasks` included everything from past dates regardless of completion status. Now the completed sidebar only receives completed tasks, and any uncompleted older tasks auto-migrate to today on load (this subsumes the old pinned-only migration). Also prevents clicking the checkbox on an unselected task from selecting it — the click no longer propagates up to the task card's select handler.

Add tasks on one day, leave some incomplete, then check the next day — they should appear in today's focus list, not the completed sidebar. Tick a checkbox on a non-selected task and confirm it completes without opening the task.