### PR TITLE
Improve tap

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -12,7 +12,11 @@ interface Props {
 
 const Checkbox: React.FC<Props> = ({ id, checked, onChange }) => {
   return (
-    <span className={cx("checkbox", { checked })}>
+    <span
+      className={cx("checkbox", { checked })}
+      role="presentation"
+      onClick={e => e.stopPropagation()}
+    >
       <label
         htmlFor={id}
         className="inline-flex items-center justify-center p-3 -m-3"

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -204,21 +204,12 @@ const Task: React.FC<Props> = ({
     (event: MouseEvent) => {
       if (active) return
 
-      const target = event.target as HTMLElement
-
-      const isCheckbox = target.closest(".checkbox")
-      if (
-        !isCheckbox &&
-        !["TEXTAREA"].includes(event.currentTarget.nodeName) &&
-        !["INPUT", "svg"].includes(target.nodeName)
-      ) {
-        onSelect(task.id, event)
-        setTimeout(() => {
-          const title = ref.current?.querySelector("textarea")
-          title?.focus()
-          title?.setSelectionRange(title?.value.length, title?.value.length)
-        })
-      }
+      onSelect(task.id, event)
+      setTimeout(() => {
+        const title = ref.current?.querySelector("textarea")
+        title?.focus()
+        title?.setSelectionRange(title?.value.length, title?.value.length)
+      })
     },
     [onSelect, task, active]
   )
@@ -359,7 +350,12 @@ const Task: React.FC<Props> = ({
           </>
         </div>
 
-        <div id="actions" className="flex items-center ml-auto shrink-0">
+        <div
+          id="actions"
+          role="presentation"
+          className="flex items-center ml-auto shrink-0"
+          onClick={e => e.stopPropagation()}
+        >
           {onMoveToToday && (
             <button
               type="button"


### PR DESCRIPTION
On mobile, tapping a checkbox, pin, delete, or any action button on an unselected task would first select the task, requiring a second tap to actually perform the action. The previous fix used a brittle selector list in `handlePress` to check if the click target was interactive — this doesn't scale.

Instead, the actions container and checkbox now call `stopPropagation()` on click, preventing the event from reaching the card's select handler. This means any current or future button inside those areas works on first tap without maintaining an exclusion list. `handlePress` is simplified back to just calling `onSelect`.

Tap the checkbox, pin, delete, or link on an unselected task — each should fire immediately without selecting the task first.