### PR TITLE
Overscroll, haptic, keyboard aware

### DIFF
--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -15,7 +15,7 @@ import Textarea from "react-textarea-autosize"
 import cx from "classnames"
 import FiLink from "@meronex/icons/fi/FiLink"
 import { useSettings } from "../context/SettingsContext"
-import { contrastText } from "../utils"
+import { contrastText, haptic } from "../utils"
 
 const MAX_DESCRIPTION_LENGTH = 1000
 
@@ -143,6 +143,7 @@ const Task: React.FC<Props> = ({
     if (isTyping) return
 
     if (event.key === "p" && state && !state.completed) {
+      haptic()
       const pinning = !Boolean(state.pinned)
       const updated = { ...state, pinned: pinning }
       setState(updated)
@@ -150,6 +151,7 @@ const Task: React.FC<Props> = ({
       if (pinning) setGlowing(true)
     }
     if (event.key === "x") {
+      haptic()
       onRemoveTask(state ?? task)
     }
     if (event.key === "m" && onMoveToToday) {
@@ -181,6 +183,7 @@ const Task: React.FC<Props> = ({
 
   const handleSelect = useCallback(() => {
     if (state) {
+      haptic()
       const updated = {
         ...state,
         completed: !state.completed,
@@ -385,6 +388,7 @@ const Task: React.FC<Props> = ({
               style={state?.pinned ? { color: "#93c5fd" } : undefined}
               onClick={preventDefault(() => {
                 if (!state) return
+                haptic()
                 const pinning = !Boolean(state.pinned)
                 const updated = { ...state, pinned: pinning }
                 setState(updated)
@@ -478,7 +482,10 @@ const Task: React.FC<Props> = ({
             data-tooltip-id="tooltip"
             data-tooltip-content="Delete (X)"
             aria-label="Delete task"
-            onClick={() => onRemoveTask(state ?? task)}
+            onClick={() => {
+              haptic()
+              onRemoveTask(state ?? task)
+            }}
           >
             <CrossIcon />
           </button>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -31,6 +31,7 @@ import ChevronUp from "@meronex/icons/fi/FiChevronUp"
 import SearchIcon from "@meronex/icons/fi/FiSearch"
 import CheckIcon from "@meronex/icons/fi/FiCheckCircle"
 import Toast from "./Toast"
+import useKeyboardAware from "../hooks/useKeyboardAware"
 
 function Title({ children }: PropsWithChildren) {
   return (
@@ -65,6 +66,7 @@ const slideTransition =
 const Todo: React.FC = ({}) => {
   const breakpoint = useMedia()
   const { settings } = useSettings()
+  useKeyboardAware()
   const {
     data,
     sections,

--- a/src/hooks/useKeyboardAware.ts
+++ b/src/hooks/useKeyboardAware.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react"
+
+export default function useKeyboardAware() {
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+
+    const onResize = () => {
+      const active = document.activeElement as HTMLElement | null
+      if (active?.tagName === "INPUT" || active?.tagName === "TEXTAREA") {
+        requestAnimationFrame(() => {
+          active.scrollIntoView({ block: "nearest", behavior: "smooth" })
+        })
+      }
+    }
+
+    vv.addEventListener("resize", onResize)
+    return () => vv.removeEventListener("resize", onResize)
+  }, [])
+}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -26,6 +26,7 @@
     touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: none;
+    overscroll-behavior: contain;
   }
 
   button,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,6 +59,10 @@ export const parseDataStr = (data: string): Record<string, unknown> => {
   }
 }
 
+export function haptic(ms = 10) {
+  navigator?.vibrate?.(ms)
+}
+
 export const preventDefault =
   (fn: (event: MouseEvent, ...args: any[]) => any) =>
   (event: MouseEvent, ...args: any[]) => {


### PR DESCRIPTION
Three mobile polish improvements: `overscroll-behavior: contain` prevents pull-to-refresh and rubber-banding from interfering with in-app scrolling. Haptic feedback (`navigator.vibrate`) fires on complete, pin, and delete actions for a more native feel — fails silently on unsupported browsers. A new `useKeyboardAware` hook listens to `visualViewport` resize events and scrolls the focused input into view when the mobile keyboard opens, preventing the task input from being hidden behind the keyboard.

Test on a real device or touch simulator — complete/pin/delete a task for vibration, open the keyboard on the task input to verify it stays visible, and scroll to confirm no bounce or pull-to-refresh interference.