### PR TITLE
Better tooltip library

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover"
     />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#151925" media="(prefers-color-scheme: dark)" />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/markmur/what-todo/issues"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@meronex/icons": "^4.0.0",
     "classnames": "^2.2.6",
     "framer-motion": "^12.38.0",
@@ -32,7 +33,6 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-textarea-autosize": "^8.3.1",
-    "react-tooltip": "^5.30.0",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/react':
+        specifier: ^0.27.19
+        version: 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@meronex/icons':
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.4)
@@ -29,9 +32,6 @@ importers:
       react-textarea-autosize:
         specifier: ^8.3.1
         version: 8.5.9(@types/react@19.2.14)(react@19.2.4)
-      react-tooltip:
-        specifier: ^5.30.0
-        version: 5.30.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -664,6 +664,18 @@ packages:
 
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -2272,12 +2284,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-tooltip@5.30.0:
-    resolution: {integrity: sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg==}
-    peerDependencies:
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2478,6 +2484,9 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -3562,6 +3571,20 @@ snapshots:
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -5148,13 +5171,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  react-tooltip@5.30.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      classnames: 2.5.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   react@19.2.4: {}
 
   readdirp@4.1.2:
@@ -5421,6 +5437,8 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tabbable@6.4.0: {}
 
   tailwindcss@4.2.2: {}
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,70 @@
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  FloatingPortal
+} from "@floating-ui/react"
+import { useState, useEffect, useRef } from "react"
+
+export default function Tooltip() {
+  const [content, setContent] = useState("")
+  const [open, setOpen] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const { refs, floatingStyles } = useFloating({
+    open,
+    placement: "top",
+    middleware: [offset(6), flip(), shift()],
+    whileElementsMounted: autoUpdate
+  })
+
+  useEffect(() => {
+    const handleOver = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement).closest?.(
+        "[data-tooltip-content]"
+      ) as HTMLElement | null
+      if (target) {
+        clearTimeout(timeoutRef.current)
+        const text = target.getAttribute("data-tooltip-content")
+        if (!text) return
+        setContent(text)
+        refs.setReference(target)
+        setOpen(true)
+      }
+    }
+
+    const handleOut = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement).closest?.(
+        "[data-tooltip-content]"
+      )
+      if (target) {
+        timeoutRef.current = setTimeout(() => setOpen(false), 50)
+      }
+    }
+
+    document.addEventListener("mouseover", handleOver)
+    document.addEventListener("mouseout", handleOut)
+    return () => {
+      document.removeEventListener("mouseover", handleOver)
+      document.removeEventListener("mouseout", handleOut)
+      clearTimeout(timeoutRef.current)
+    }
+  }, [refs])
+
+  if (!open || !content) return null
+
+  return (
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        role="tooltip"
+        style={floatingStyles}
+        className="bg-black text-white text-xs rounded px-2 py-1 z-[9999] pointer-events-none"
+      >
+        {content}
+      </div>
+    </FloatingPortal>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react"
 import ContextWrapper from "./App"
 // Components
 import Todo from "./components/Todo"
-import { Tooltip } from "react-tooltip"
+import Tooltip from "./components/Tooltip"
 import { createRoot } from "react-dom/client"
 import { useStorage } from "./context/StorageContext"
 
@@ -27,7 +27,7 @@ const App = () => {
   return (
     <main>
       <Todo />
-      <Tooltip id="tooltip" place="top" style={{ backgroundColor: "black" }} />
+      <Tooltip />
     </main>
   )
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -201,6 +201,7 @@
     width: 44px;
     height: 44px;
     transform: translate(-50%, -50%);
+    pointer-events: none;
   }
 
   .remove-icon {


### PR DESCRIPTION
react-tooltip v5 doesn't work with React 19 + Chrome 146 — the MutationObserver that discovers anchor elements only handles removals, not additions, so dynamically rendered elements (anything inside Framer Motion's AnimatePresence) never get tooltip listeners attached. Replaced it with a custom Tooltip component built on @floating-ui/react that uses document-level event delegation on mouseover/mouseout, matching any element with a data-tooltip-content attribute. This works regardless of when elements enter the DOM and has zero per-element setup.

Also adds pointer-events: none on the .touch-target pseudo-element so hover events pass through to buttons, and replaces the deprecated apple-mobile-web-app-capable meta tag.

Hover over any action button (pin, delete, labels) on a task to verify tooltips appear. Check footer icons too.