### PR TITLE
Colour picker sheet

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -15,6 +15,7 @@ const Checkbox: React.FC<Props> = ({ id, checked, onChange }) => {
     <span
       className={cx("checkbox", { checked })}
       role="presentation"
+      onPointerDown={e => e.stopPropagation()}
       onClick={e => e.stopPropagation()}
     >
       <label
@@ -22,9 +23,15 @@ const Checkbox: React.FC<Props> = ({ id, checked, onChange }) => {
         className="inline-flex items-center justify-center p-3 -m-3"
       >
         {checked ? (
-          <Checked className="text-slate-500 hover:text-slate-800 dark:text-navy-500 dark:hover:text-navy-300" />
+          <Checked
+            fontSize={22}
+            className="text-slate-500 hover:text-slate-800 dark:text-navy-500 dark:hover:text-navy-300"
+          />
         ) : (
-          <Unchecked className="text-slate-600 hover:text-black dark:text-navy-400 dark:hover:text-navy-200" />
+          <Unchecked
+            fontSize={22}
+            className="text-slate-600 hover:text-black dark:text-navy-400 dark:hover:text-navy-200"
+          />
         )}
       </label>
       <input

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,11 +1,13 @@
 import React, { useRef, useLayoutEffect, useState } from "react"
 import colors, { Color } from "../color-palette"
+import { AnimatePresence, motion } from "framer-motion"
 
 import Portal from "./Portal"
 import useOnClickOutside from "../hooks/onclickoutside"
 
 interface Props {
   visible: boolean
+  label?: string
   children: React.ReactElement
   onChange: (color: Color) => void
   onHide: () => void
@@ -13,6 +15,7 @@ interface Props {
 
 const ColorPicker: React.FC<Props> = ({
   visible = true,
+  label,
   children,
   onChange,
   onHide
@@ -21,43 +24,124 @@ const ColorPicker: React.FC<Props> = ({
   const internalRef = useRef<HTMLDivElement>(null)
   const width = 120
   const [style, setStyle] = useState<React.CSSProperties>({})
+  const [useSheet, setUseSheet] = useState(
+    () => !window.matchMedia("(min-width: 64em)").matches
+  )
+
+  React.useEffect(() => {
+    const mql = window.matchMedia("(min-width: 64em)")
+    const handler = (e: MediaQueryListEvent) => setUseSheet(!e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [])
 
   useLayoutEffect(() => {
-    if (visible && childRef.current) {
+    if (visible && childRef.current && !useSheet) {
       const dimensions = childRef.current.getBoundingClientRect()
       setStyle({
         left: dimensions.left + dimensions.width / 2 - width / 2,
         top: dimensions.top - 128
       })
     }
-  }, [visible, width])
+  }, [visible, width, useSheet])
 
   useOnClickOutside(internalRef, onHide, { ignore: "color-picker-item" })
+
+  const handleSelect = (color: Color) => {
+    onChange(color)
+    if (useSheet) onHide()
+  }
 
   return (
     <div>
       <div ref={childRef}>{children}</div>
 
-      {visible && (
+      {visible && !useSheet && (
         <Portal>
           <div className="color-picker" style={style} ref={internalRef}>
-            <div className={"flex flex-wrap"} style={{ width }}>
+            <div className="flex flex-wrap" style={{ width }}>
               {colors.map(color => (
                 <button
                   type="button"
-                  className="no-style w-[16px] h-[16px] rounded-lg p-0 m-1 grow-0 shrink-0 flex-basis-[16px] cursor-pointer color-picker-item"
+                  className="no-style w-[16px] h-[16px] rounded-full p-0 m-1 grow-0 shrink-0 cursor-pointer color-picker-item"
                   key={color.name}
-                  data-tooltip-id="tooltip"
                   data-tooltip-content={color.name}
                   aria-label={color.name}
                   style={{ backgroundColor: color.backgroundColor }}
-                  onClick={() => onChange(color)}
+                  onClick={() => handleSelect(color)}
                 />
               ))}
             </div>
           </div>
         </Portal>
       )}
+
+      <Portal>
+        <AnimatePresence>
+          {visible && useSheet && (
+            <>
+              <motion.div
+                key="color-picker-backdrop"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 bg-black/40 z-60"
+                onClick={onHide}
+                aria-hidden="true"
+              />
+              <motion.div
+                key="color-picker-sheet"
+                ref={internalRef}
+                initial={{ y: "100%" }}
+                animate={{ y: 0 }}
+                exit={{ y: "100%" }}
+                transition={{ type: "spring", damping: 30, stiffness: 300 }}
+                className="fixed bottom-0 left-0 right-0 z-60 bg-white dark:bg-navy-800 rounded-t-2xl shadow-xl"
+                style={{
+                  paddingBottom: "max(16px, env(safe-area-inset-bottom, 16px))"
+                }}
+              >
+                <div className="flex justify-center pt-2 pb-1">
+                  <div className="w-10 h-1 rounded-full bg-slate-300 dark:bg-navy-600" />
+                </div>
+                {label && (
+                  <p className="text-center text-sm text-slate-500 dark:text-navy-400 py-5">
+                    Choose a color for{" "}
+                    <span className="font-semibold text-slate-700 dark:text-navy-200">
+                      {label}
+                    </span>
+                  </p>
+                )}
+                <div
+                  className="grid gap-y-3 px-4 pb-4 mx-auto justify-items-center"
+                  style={{
+                    gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+                    maxWidth: 400
+                  }}
+                >
+                  {colors.map(color => (
+                    <button
+                      type="button"
+                      className="no-style flex flex-col items-center gap-1 cursor-pointer color-picker-item"
+                      key={color.name}
+                      aria-label={color.name}
+                      onClick={() => handleSelect(color)}
+                    >
+                      <span
+                        className="w-[32px] h-[32px] rounded-full block"
+                        style={{ backgroundColor: color.backgroundColor }}
+                      />
+                      <span className="text-[9px] leading-tight text-slate-400 dark:text-navy-500 w-full text-center line-clamp-2">
+                        {color.name}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      </Portal>
     </div>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -94,7 +94,7 @@ function Header({
       </div>
       {onMenuClick && (
         <button
-          className="no-style md:hidden dark:text-navy-100"
+          className="no-style dark:text-navy-100"
           onClick={onMenuClick}
           aria-label="Open menu"
         >

--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -127,6 +127,7 @@ const Labels: React.FC<Props> = ({
               <div className="mr-2">
                 <ColorPicker
                   visible={label.id === selectedLabel}
+                  label={label.title}
                   onHide={() => setSelectedLabel(undefined)}
                   onChange={color => handleColorChange(color, label)}
                 >

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -206,6 +206,8 @@ const Task: React.FC<Props> = ({
   const handlePress = useCallback(
     (event: MouseEvent) => {
       if (active) return
+      const target = event.target as HTMLElement
+      if (target.closest(".checkbox, #actions")) return
 
       onSelect(task.id, event)
       setTimeout(() => {
@@ -370,7 +372,7 @@ const Task: React.FC<Props> = ({
                 onMoveToToday(state ?? task)
               })}
             >
-              <RightArrowIcon />
+              <RightArrowIcon fontSize={20} />
             </button>
           )}
 
@@ -396,7 +398,11 @@ const Task: React.FC<Props> = ({
                 if (pinning) setGlowing(true)
               })}
             >
-              {state?.pinned ? <PinFilled /> : <Pin />}
+              {state?.pinned ? (
+                <PinFilled fontSize={20} />
+              ) : (
+                <Pin fontSize={20} />
+              )}
             </button>
           )}
 
@@ -413,7 +419,7 @@ const Task: React.FC<Props> = ({
                 window.open(descriptionURL, "_blank")
               })}
             >
-              <FiLink />
+              <FiLink fontSize={20} />
             </button>
           )}
 
@@ -462,7 +468,7 @@ const Task: React.FC<Props> = ({
                   key={id}
                   role="button"
                   tabIndex={0}
-                  className="w-[16px] h-[16px] rounded-lg p-0 ml-1 grow-0 shrink-0 cursor-pointer"
+                  className="w-[20px] h-[20px] rounded-full p-0 ml-2 grow-0 shrink-0 cursor-pointer"
                   data-tooltip-id="tooltip"
                   data-tooltip-content={labels[id]?.title}
                   aria-label={labels[id]?.title}
@@ -487,7 +493,7 @@ const Task: React.FC<Props> = ({
               onRemoveTask(state ?? task)
             }}
           >
-            <CrossIcon />
+            <CrossIcon fontSize={20} />
           </button>
         </div>
       </div>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -8,7 +8,6 @@ import type {
 import React, { PropsWithChildren, useCallback, useState } from "react"
 // utils
 import { formatDateHeading, today } from "../utils"
-import useMedia, { Breakpoints } from "../hooks/media"
 
 import Footer from "./Footer"
 import Labels from "./Labels"
@@ -64,7 +63,6 @@ const slideTransition =
   "left 0.3s cubic-bezier(0.4, 0, 0.2, 1), right 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
 
 const Todo: React.FC = ({}) => {
-  const breakpoint = useMedia()
   const { settings } = useSettings()
   useKeyboardAware()
   const {
@@ -196,8 +194,16 @@ const Todo: React.FC = ({}) => {
 
   const fullHeight = "calc(100dvh - 66px - env(safe-area-inset-bottom, 0px))"
 
-  const isDesktop =
-    breakpoint != Breakpoints.MOBILE && breakpoint != Breakpoints.TABLET
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.matchMedia("(min-width: 64em)").matches
+  )
+
+  React.useEffect(() => {
+    const mql = window.matchMedia("(min-width: 64em)")
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [])
 
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [labelsCollapsed, setLabelsCollapsed] = useState(false)

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -224,7 +224,7 @@
   }
 
   .checkbox label {
-    font-size: 20px;
+    font-size: 22px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
Several mobile UX issues addressed in one pass. Icons (checkbox, pin, delete, link, arrow) were too small — bumped to 20-22px with explicit fontSize props. Label circles increased from 16px to 20px with full rounding. The color picker popup was hidden behind the mobile drawer (z-index conflict) — replaced with an iOS-style bottom sheet on screens below 1024px, showing a 5-column grid of colors with names underneath and a "Choose a color for {label}" title. The checkbox 2-tap issue is fixed with both onPointerDown stopPropagation and a closest() guard in handlePress. The hamburger menu now appears at the correct breakpoint (1024px) instead of leaving a dead zone between 768-1024px where neither the hamburger nor the desktop sidebar toggles were visible.

Resize the browser through mobile/tablet/desktop widths to verify the hamburger menu appears correctly. On mobile, tap a label color circle to see the bottom sheet. Verify checkboxes toggle on first tap without selecting the task.