### PR TITLE
Polish: progress badge, empty state, transitions, contrast, and bug fixes

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -42,6 +42,30 @@ test("full app workflow", async ({ page }) => {
     await expect(page.getByText("From the farmers market")).toBeVisible()
   })
 
+  await test.step("add description from empty keeps focus", async () => {
+    await page.getByText("Write tests").click()
+    const card = page
+      .locator("[role='button']")
+      .filter({ hasText: "Write tests" })
+    const desc = card.locator("textarea[name='description']")
+    await desc.focus()
+    await desc.pressSequentially("My new description")
+    await expect(desc).toBeFocused()
+    await expect(desc).toHaveValue("My new description")
+    await page.keyboard.press("Escape")
+  })
+
+  await test.step("clicking empty space deselects task", async () => {
+    await page.getByText("Write tests").click()
+    const card = page
+      .locator("[role='button']")
+      .filter({ hasText: "Write tests" })
+    await expect(card.locator("textarea.task-title-input")).toBeVisible()
+    // Click the search input area (outside any task)
+    await page.getByPlaceholder("Search tasks...").click()
+    await expect(card.locator("textarea.task-title-input")).toBeHidden()
+  })
+
   await test.step("toggle labels on a task", async () => {
     await page.getByText("Write tests").click()
     // Click "Work" label in the edit view to add it
@@ -110,12 +134,32 @@ test("full app workflow", async ({ page }) => {
       .toBe(true)
   })
 
-  await test.step("input closes after adding a task", async () => {
+  await test.step("input stays open when clicking label inside it", async () => {
+    const taskInput = page.getByPlaceholder("What needs to be done?")
+    await taskInput.focus()
+    await expect(page.locator("#task-description")).toBeVisible()
+    // Click a label button inside the expanded input
+    const labelBtn = page
+      .locator("#task-description")
+      .locator("..")
+      .locator("..")
+      .getByText("Work")
+    await labelBtn.click()
+    // The input section should still be expanded
+    await expect(page.locator("#task-description")).toBeVisible()
+    await page.keyboard.press("Escape")
+  })
+
+  await test.step("input stays open on desktop after adding a task", async () => {
     const taskInput = page.getByPlaceholder("What needs to be done?")
     await taskInput.focus()
     await expect(page.locator("#task-description")).toBeVisible()
     await taskInput.fill("Temp task")
     await taskInput.press("Enter")
+    // On desktop (fine pointer), input stays open for quick entry
+    await expect(page.locator("#task-description")).toBeVisible()
+    // Click outside to close
+    await page.locator("h1").first().click()
     await expect(page.locator("#task-description")).toBeHidden()
   })
 

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -37,7 +37,7 @@ const Checkbox: React.FC<Props> = ({ id, checked, onChange }) => {
       {checked ? (
         <Checked
           fontSize={22}
-          className="text-slate-500 hover:text-slate-800 dark:text-navy-500 dark:hover:text-navy-300"
+          className="text-slate-500 hover:text-slate-800 dark:text-navy-400 dark:hover:text-navy-300"
         />
       ) : (
         <Unchecked

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,12 +38,14 @@ async function seedFromFile() {
 function Header({
   className,
   onMenuClick,
-  taskCount,
+  completedCount,
+  totalCount,
   date
 }: {
   className?: string
   onMenuClick?: () => void
-  taskCount?: number
+  completedCount?: number
+  totalCount?: number
   date?: string
 }) {
   const tapCount = useRef(0)
@@ -78,16 +80,16 @@ function Header({
         >
           What Todo 🤷‍♂️
         </h1>
-        {typeof taskCount === "number" && (
+        {typeof totalCount === "number" && (
           <span
             className="text-xs font-semibold bg-slate-200 dark:bg-navy-700 text-slate-600 dark:text-navy-300 rounded-full px-2 py-0.5 leading-none"
             style={{ verticalAlign: "baseline" }}
           >
-            {taskCount}
+            {completedCount}/{totalCount}
           </span>
         )}
         {date && (
-          <span className="text-xs text-slate-400 dark:text-navy-500 leading-none">
+          <span className="text-xs text-slate-400 dark:text-navy-400 leading-none">
             {date}
           </span>
         )}

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -2,13 +2,19 @@ import { Label as LabelType, Task as TaskType } from "../index.d"
 import React, { useCallback, useRef } from "react"
 
 // Icons
+import CheckCircle from "@meronex/icons/fi/FiCheckCircle"
 import ChevronDown from "@meronex/icons/fi/FiChevronDown"
 import ChevronUp from "@meronex/icons/fi/FiChevronUp"
 import Task from "./Task"
 import cx from "classnames"
 import useOnClickOutside from "../hooks/onclickoutside"
 import { useSettings } from "../context/SettingsContext"
-import { Reorder, useDragControls } from "framer-motion"
+import {
+  AnimatePresence,
+  Reorder,
+  motion,
+  useDragControls
+} from "framer-motion"
 import GripIcon from "@meronex/icons/fi/FiMenu"
 import Animate from "./Animate"
 
@@ -206,10 +212,27 @@ const List: React.FC<Props> = ({
   }
 
   return (
-    <div ref={selectedRef}>
+    <div
+      ref={selectedRef}
+      className="h-full"
+      onPointerUp={e => {
+        const target = e.target as HTMLElement
+        if (!target.closest("[role='button'], [role='checkbox'], button, textarea, input, #actions")) {
+          setSelectedTask(undefined)
+        }
+      }}
+    >
       {uncompleted.length === 0 && !hasCompletedTasks && onReorder && (
-        <div className="text-slate-400 dark:text-navy-500 text-sm text-center py-12">
-          {isFiltering ? "No tasks found." : "Nothing to do — enjoy your day!"}
+        <div className="text-slate-400 dark:text-navy-400 text-sm text-center flex flex-col items-center justify-center h-full gap-3">
+          <CheckCircle
+            fontSize={48}
+            className="text-slate-300 dark:text-navy-600"
+          />
+          <span>
+            {isFiltering
+              ? "No tasks found."
+              : "Nothing to do — enjoy your day!"}
+          </span>
         </div>
       )}
 
@@ -243,19 +266,27 @@ const List: React.FC<Props> = ({
             compact: forceCompact || settings.compactMode
           })}
         >
-          {uncompleted.map(task => (
-            <li key={task.id} className="task">
-              <Task
-                {...callbackHandlers}
-                active={task.id === selected}
-                task={task}
-                labels={labels}
-                filters={filters}
-                canPin={canPinTasks}
-                compact={forceCompact || settings.compactMode}
-              />
-            </li>
-          ))}
+          <AnimatePresence initial={false}>
+            {uncompleted.map(task => (
+              <motion.li
+                key={task.id}
+                className="task"
+                layout
+                exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                <Task
+                  {...callbackHandlers}
+                  active={task.id === selected}
+                  task={task}
+                  labels={labels}
+                  filters={filters}
+                  canPin={canPinTasks}
+                  compact={forceCompact || settings.compactMode}
+                />
+              </motion.li>
+            ))}
+          </AnimatePresence>
         </ul>
       )}
 
@@ -303,19 +334,27 @@ const List: React.FC<Props> = ({
             compact: forceCompact || settings.compactMode
           })}
         >
-          {completed.map(task => (
-            <li key={task.id} className="task">
-              <Task
-                {...callbackHandlers}
-                active={task.id === selected}
-                task={task}
-                canPin={canPinTasks}
-                labels={labels}
-                filters={filters}
-                compact={forceCompact || settings.compactMode}
-              />
-            </li>
-          ))}
+          <AnimatePresence initial={false}>
+            {completed.map(task => (
+              <motion.li
+                key={task.id}
+                className="task"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                transition={{ duration: 0.3 }}
+              >
+                <Task
+                  {...callbackHandlers}
+                  active={task.id === selected}
+                  task={task}
+                  canPin={canPinTasks}
+                  labels={labels}
+                  filters={filters}
+                  compact={forceCompact || settings.compactMode}
+                />
+              </motion.li>
+            ))}
+          </AnimatePresence>
         </ul>
       </Animate>
     </div>

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -217,7 +217,11 @@ const List: React.FC<Props> = ({
       className="h-full"
       onPointerUp={e => {
         const target = e.target as HTMLElement
-        if (!target.closest("[role='button'], [role='checkbox'], button, textarea, input, #actions")) {
+        if (
+          !target.closest(
+            "[role='button'], [role='checkbox'], button, textarea, input, #actions"
+          )
+        ) {
           setSelectedTask(undefined)
         }
       }}

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -315,7 +315,6 @@ const Task: React.FC<Props> = ({
             )}
 
             <Animate active={active}>
-
               <div className="flex mt-2 flex-wrap">
                 {Object.entries(labels).map(([id, label]) => (
                   <div className="mr-1 mb-1" key={id}>

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -221,7 +221,7 @@ const Task: React.FC<Props> = ({
   )
 
   return (
-    <Animate active duration={0.15}>
+    <Animate active duration={0.15} skipInitial>
       <div
         ref={ref}
         role="button"
@@ -263,7 +263,7 @@ const Task: React.FC<Props> = ({
               className={cx(
                 "unstyled task-title-input font-semibold text-slate-700 dark:text-navy-100 leading-normal bg-transparent pt-0",
                 {
-                  ["text-slate-400 dark:text-navy-500"]: state?.completed
+                  ["text-slate-400 dark:text-navy-400"]: state?.completed
                 }
               )}
               onKeyDown={handleKeyDown}
@@ -276,7 +276,7 @@ const Task: React.FC<Props> = ({
               className={cx(
                 "inline font-semibold text-slate-700 dark:text-navy-100",
                 {
-                  ["text-slate-400 dark:text-navy-500"]: state?.completed
+                  ["text-slate-400 dark:text-navy-400"]: state?.completed
                 }
               )}
             >
@@ -298,13 +298,13 @@ const Task: React.FC<Props> = ({
           )}
 
           <>
-            {state?.description && (
+            {(state?.description || active) && (
               <div className="mt-1">
                 <Textarea
                   maxRows={10}
                   name="description"
                   value={getDescription(active, state?.description)}
-                  placeholder=""
+                  placeholder={active ? "Add description..." : ""}
                   className="unstyled text-slate-500 dark:text-navy-400 text-sm bg-transparent max-h-[800px]"
                   onChange={handleChange("description")}
                   onKeyDown={handleKeyDown}
@@ -315,21 +315,6 @@ const Task: React.FC<Props> = ({
             )}
 
             <Animate active={active}>
-              {!state?.description && (
-                <div className="mt-1">
-                  <Textarea
-                    maxRows={10}
-                    name="description"
-                    value=""
-                    placeholder="Add description..."
-                    className="unstyled text-slate-500 dark:text-navy-400 text-sm bg-transparent max-h-[800px]"
-                    onChange={handleChange("description")}
-                    onKeyDown={handleKeyDown}
-                    onFocus={selectTask}
-                    onBlur={handleBlur}
-                  />
-                </div>
-              )}
 
               <div className="flex mt-2 flex-wrap">
                 {Object.entries(labels).map(([id, label]) => (

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -67,13 +67,15 @@ const TaskInput: React.FC<Props> = ({
       })
     }
 
+  const isMobile = window.matchMedia("(pointer: coarse)").matches
+
   const handleAdd = React.useCallback(() => {
     if (validTask(task)) {
       onAdd(task as Task)
       clearTask()
-      setOpen(false)
+      if (isMobile) setOpen(false)
     }
-  }, [task, onAdd, clearTask])
+  }, [task, onAdd, clearTask, isMobile])
 
   const handleLabelClick = (id: string) => {
     const currentLabels = task.labels ?? []
@@ -154,7 +156,7 @@ const TaskInput: React.FC<Props> = ({
               minRows={1}
               maxRows={6}
               value={task.description}
-              className="sm:text-md md:text-sm border-top w-full bg-transparent py-2 mb-3 outline-hidden resize-none border-top border-slate-200 dark:border-navy-700 placeholder-slate-400 dark:placeholder-navy-500 dark:text-navy-100"
+              className="sm:text-md md:text-sm border-top w-full bg-transparent py-2 mb-3 outline-hidden resize-none border-top border-slate-200 dark:border-navy-700 placeholder-slate-400 dark:placeholder-navy-400 dark:text-navy-100"
               placeholder="Add a description or URL..."
               onChange={handleChange("description")}
               onKeyDown={handleKeyDown("description")}

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -241,7 +241,8 @@ const Todo: React.FC = ({}) => {
         onMenuClick={
           !isDesktop ? () => setDrawerOpen(prev => !prev) : undefined
         }
-        taskCount={todaysTasks.filter(t => !t.completed).length}
+        completedCount={todaysTasks.filter(t => t.completed).length}
+        totalCount={todaysTasks.length}
         date={formatDateHeading(todayDateStr)}
       />
       <main>
@@ -301,7 +302,7 @@ const Todo: React.FC = ({}) => {
 
                 <div className="w-full overflow-y-auto flex-1 min-h-0">
                   {olderTasks.length === 0 ? (
-                    <div className="text-slate-400 dark:text-navy-500 text-sm text-center flex flex-col items-center justify-center h-full gap-3">
+                    <div className="text-slate-400 dark:text-navy-400 text-sm text-center flex flex-col items-center justify-center h-full gap-3">
                       <CheckIcon
                         fontSize={32}
                         className="text-slate-300 dark:text-navy-600"
@@ -560,7 +561,7 @@ const Todo: React.FC = ({}) => {
                         if (e.key === "Escape") setSearchQuery("")
                       }}
                       placeholder="Search tasks..."
-                      className="w-full text-sm bg-slate-100/70 dark:bg-navy-800/70 backdrop-blur-md rounded-lg pl-8 pr-3 py-2.5 outline-none placeholder-slate-400 dark:placeholder-navy-500 dark:text-navy-100 border border-slate-200/50 dark:border-navy-700/50"
+                      className="w-full text-sm bg-slate-100/70 dark:bg-navy-800/70 backdrop-blur-md rounded-lg pl-8 pr-3 py-2.5 outline-none placeholder-slate-400 dark:placeholder-navy-400 dark:text-navy-100 border border-slate-200/50 dark:border-navy-700/50"
                     />
                   </div>
                 </div>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -46,11 +46,17 @@ export default function Tooltip() {
       }
     }
 
+    const dismiss = () => setOpen(false)
+
     document.addEventListener("mouseover", handleOver)
     document.addEventListener("mouseout", handleOut)
+    document.addEventListener("pointerdown", dismiss)
+    document.addEventListener("scroll", dismiss, true)
     return () => {
       document.removeEventListener("mouseover", handleOver)
       document.removeEventListener("mouseout", handleOut)
+      document.removeEventListener("pointerdown", dismiss)
+      document.removeEventListener("scroll", dismiss, true)
       clearTimeout(timeoutRef.current)
     }
   }, [refs])

--- a/src/hooks/useKeyboardAware.ts
+++ b/src/hooks/useKeyboardAware.ts
@@ -1,11 +1,20 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 export default function useKeyboardAware() {
+  const prevHeight = useRef(0)
+
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
 
+    prevHeight.current = vv.height
+
     const onResize = () => {
+      const delta = Math.abs(vv.height - prevHeight.current)
+      prevHeight.current = vv.height
+
+      if (delta < 100) return
+
       const active = document.activeElement as HTMLElement | null
       if (active?.tagName === "INPUT" || active?.tagName === "TEXTAREA") {
         requestAnimationFrame(() => {


### PR DESCRIPTION
A batch of polish and bug fixes. Progress indicator changed from a task count to a completed/total fraction badge (e.g. "3/8"). Empty state now shows a check-circle icon centered vertically. Task completion and uncompleting animate with opacity/height transitions via AnimatePresence. Dark mode color contrast improved by bumping navy-500 text to navy-400 across completed tasks, placeholders, header date, and empty states.

Bug fixes: tooltip now dismisses on pointerdown and scroll (was staying visible after reorder/pin/complete). Description field no longer unmounts when typing the first character from empty — unified into a single textarea that shows conditionally. Clicking outside a selected task (but inside the focus area) now deselects it. TaskInput stays open on desktop after adding a task for quick multi-entry, closes on mobile. useKeyboardAware no longer fires scrollIntoView on small viewport changes (textarea auto-grow), only on keyboard open/close (100px+ delta). Tasks no longer animate on initial page load (skipInitial). Inline label circles hidden when task is active since the expanded section already shows editable labels.

New e2e tests cover: adding a description from empty, deselecting by clicking empty space, and TaskInput staying open when clicking labels inside it.