### PR TITLE
Add MCP support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,3 +5,9 @@ VITE_MCP_RELAY_TOKEN=
 # Your Supabase project (what-todo.app identity + default data store)
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+
+# MCP server — Supabase mode (direct DB access, bypasses relay)
+# SUPABASE_URL and SERVICE_ROLE_KEY can be the same project as above
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+WHATTODO_API_TOKEN=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+  command = "pnpm build && git diff --quiet HEAD~1 HEAD -- supabase/functions/ 2>/dev/null || supabase functions deploy mcp --project-ref $SUPABASE_PROJECT_REF"
+  publish = "dist"
+
+[[redirects]]
+  from = "/mcp"
+  to = "https://<your-project>.supabase.co/functions/v1/mcp"
+  status = 200
+  force = true
+
+# SPA fallback — must be last
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,10 @@
 [build]
-  command = "pnpm build && git diff --quiet HEAD~1 HEAD -- supabase/functions/ 2>/dev/null || supabase functions deploy mcp --project-ref $SUPABASE_PROJECT_REF"
+  command = "pnpm build && (git diff --quiet HEAD~1 HEAD -- supabase/functions/ || supabase functions deploy mcp --project-ref $SUPABASE_PROJECT_REF)"
   publish = "dist"
 
 [[redirects]]
   from = "/mcp"
-  to = "https://<your-project>.supabase.co/functions/v1/mcp"
+  to = "$SUPABASE_URL/functions/v1/mcp"
   status = 200
   force = true
 

--- a/package.json
+++ b/package.json
@@ -27,14 +27,17 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.19",
     "@meronex/icons": "^4.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@supabase/supabase-js": "^2.101.1",
     "classnames": "^2.2.6",
+    "express": "^5.2.1",
     "framer-motion": "^12.38.0",
     "lodash-es": "^4.17.20",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-textarea-autosize": "^8.3.1",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
@@ -42,6 +45,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@types/express": "^5.0.6",
     "@types/lodash-es": "^4.17.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -56,6 +60,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "happy-dom": "^20.8.9",
     "prettier": "^3.0.3",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
     "vite-plugin-pwa": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -27,17 +27,14 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.19",
     "@meronex/icons": "^4.0.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@supabase/supabase-js": "^2.101.1",
     "classnames": "^2.2.6",
-    "express": "^5.2.1",
     "framer-motion": "^12.38.0",
     "lodash-es": "^4.17.20",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-textarea-autosize": "^8.3.1",
-    "tailwindcss": "^4.2.2",
-    "zod": "^4.3.6"
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
@@ -45,6 +42,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/express": "^5.0.6",
     "@types/lodash-es": "^4.17.4",
     "@types/react": "^19.2.14",
@@ -59,8 +57,10 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "happy-dom": "^20.8.9",
+    "express": "^5.2.1",
     "prettier": "^3.0.3",
     "tsx": "^4.21.0",
+    "zod": "^4.3.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
     "vite-plugin-pwa": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,18 +14,12 @@ importers:
       '@meronex/icons':
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.4)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       '@supabase/supabase-js':
         specifier: ^2.101.1
         version: 2.101.1
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -44,13 +38,13 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.1
         version: 4.11.1(playwright-core@1.59.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -102,6 +96,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@10.2.0(jiti@2.6.1))
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -123,6 +120,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@meronex/icons':
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.4)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@supabase/supabase-js':
         specifier: ^2.101.1
         version: 2.101.1
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -38,6 +44,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.1
@@ -47,13 +56,16 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))
+        version: 4.2.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/lodash-es':
         specifier: ^4.17.4
         version: 4.17.12
@@ -71,7 +83,7 @@ importers:
         version: 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
       eslint:
         specifier: ^10.2.0
         version: 10.2.0(jiti@2.6.1)
@@ -96,18 +108,21 @@ importers:
       prettier:
         specifier: ^3.0.3
         version: 3.8.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
       vite-plugin-pwa:
         specifier: ^1.2.0
-        version: 1.2.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))(workbox-build@7.4.0)(workbox-window@7.4.0)
+        version: 1.2.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))
+        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
 
 packages:
 
@@ -632,6 +647,162 @@ packages:
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -683,6 +854,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -726,6 +903,16 @@ packages:
     resolution: {integrity: sha512-WnoxUT02qawZSvsoPSwe7YOqOk0APysIHugiD3dYdc/QNeoigN4PD8mmmtmZFKlv8/Z7eERub0BmPkWcJ1BI+w==}
     peerDependencies:
       react: '*'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -1119,8 +1306,14 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1134,6 +1327,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1146,6 +1348,12 @@ packages:
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1156,6 +1364,12 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1267,6 +1481,10 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1276,6 +1494,14 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -1375,6 +1601,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -1392,6 +1622,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1433,11 +1667,31 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1489,6 +1743,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1504,6 +1762,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -1514,6 +1775,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -1554,9 +1819,17 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1651,9 +1924,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1686,6 +1981,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1705,6 +2004,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -1718,6 +2021,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -1765,6 +2072,9 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1824,9 +2134,21 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -1846,9 +2168,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1917,6 +2250,9 @@ packages:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1980,6 +2316,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1996,6 +2335,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2141,6 +2483,22 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2177,11 +2535,19 @@ packages:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2206,6 +2572,13 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2225,6 +2598,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2240,6 +2617,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2253,6 +2633,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -2297,12 +2681,28 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -2356,6 +2756,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -2371,6 +2774,10 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -2385,6 +2792,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sass@1.99.0:
     resolution: {integrity: sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==}
@@ -2403,8 +2813,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2417,6 +2835,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2475,6 +2896,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2557,6 +2982,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -2569,6 +2998,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2576,6 +3010,10 @@ packages:
   type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2629,6 +3067,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -2668,6 +3110,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-plugin-pwa@1.2.0:
     resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
@@ -2848,6 +3294,9 @@ packages:
   workbox-window@7.4.0:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -2866,6 +3315,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -3567,6 +4021,84 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.2.0(jiti@2.6.1))':
     dependencies:
       eslint: 10.2.0(jiti@2.6.1)
@@ -3622,6 +4154,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@hono/node-server@1.19.13(hono@4.12.12)':
+    dependencies:
+      hono: 4.12.12
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3664,6 +4200,28 @@ snapshots:
       camelcase: 5.3.1
       ncp: 2.0.0
       react: 19.2.4
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -3953,12 +4511,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3988,10 +4546,19 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.5.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.5.2
 
   '@types/deep-eql@4.0.2': {}
 
@@ -4000,6 +4567,21 @@ snapshots:
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.5.2
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4013,6 +4595,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -4022,6 +4608,15 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.5.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.5.2
 
   '@types/trusted-types@2.0.7': {}
 
@@ -4122,10 +4717,10 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -4136,13 +4731,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -4168,11 +4763,20 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -4286,6 +4890,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -4308,6 +4926,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4345,11 +4965,24 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4401,6 +5034,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4413,6 +5048,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -4420,6 +5057,8 @@ snapshots:
   electron-to-chromium@1.5.331: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -4512,7 +5151,38 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4638,7 +5308,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -4662,6 +5378,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -4683,6 +5410,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
   framer-motion@12.38.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       motion-dom: 12.38.0
@@ -4692,6 +5421,8 @@ snapshots:
       '@emotion/is-prop-valid': 0.8.8
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  fresh@2.0.0: {}
 
   fs-extra@9.1.0:
     dependencies:
@@ -4748,6 +5479,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@6.0.2:
     dependencies:
@@ -4811,7 +5546,21 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.12: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   iceberg-js@0.8.1: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb@7.1.1: {}
 
@@ -4824,11 +5573,17 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4901,6 +5656,8 @@ snapshots:
 
   is-obj@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4960,6 +5717,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -4969,6 +5728,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5085,6 +5846,16 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -5113,10 +5884,14 @@ snapshots:
 
   ncp@2.0.0: {}
 
+  negotiator@1.0.0: {}
+
   node-addon-api@7.1.1:
     optional: true
 
   node-releases@2.0.37: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -5147,6 +5922,14 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5172,6 +5955,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5183,6 +5968,8 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -5190,6 +5977,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.59.1: {}
 
@@ -5225,11 +6014,29 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
 
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -5295,6 +6102,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -5329,6 +6138,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -5350,6 +6169,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sass@1.99.0:
     dependencies:
       chokidar: 4.0.3
@@ -5365,9 +6186,34 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -5390,6 +6236,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5447,6 +6295,8 @@ snapshots:
   sourcemap-codec@1.4.8: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -5547,6 +6397,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -5557,11 +6409,24 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
   type-fest@0.16.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5624,6 +6489,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -5655,18 +6522,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  vite-plugin-pwa@1.2.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))(workbox-build@7.4.0)(workbox-window@7.4.0):
+  vary@1.1.2: {}
+
+  vite-plugin-pwa@1.2.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
       workbox-build: 7.4.0
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5675,18 +6544,20 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.2
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.99.0
       terser: 5.46.1
+      tsx: 4.21.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)):
+  vitest@4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -5703,7 +6574,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2
@@ -5886,11 +6757,17 @@ snapshots:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.0
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
 
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,11 @@
 import crypto from "node:crypto"
 import type { RequestHandler } from "express"
+import { validateApiToken, isSupabaseConfigured } from "./supabase.js"
 
+/**
+ * Fallback token for relay mode (no Supabase configured).
+ * Randomly generated per process, or read from MCP_AUTH_TOKEN env.
+ */
 export const AUTH_TOKEN =
   process.env.MCP_AUTH_TOKEN || crypto.randomBytes(24).toString("hex")
 
@@ -10,7 +15,6 @@ export const headerAuth: RequestHandler = (req, res, next) => {
     next()
     return
   }
-
   res.status(401).json({ error: "Unauthorized" })
 }
 
@@ -28,4 +32,15 @@ export const headerOrQueryAuth: RequestHandler = (req, res, next) => {
   }
 
   res.status(401).json({ error: "Unauthorized" })
+}
+
+/**
+ * Validate a WHATTODO_API_TOKEN against the users table.
+ * Falls back to the hardcoded relay token if Supabase is not configured.
+ */
+export async function validateToken(token: string): Promise<string | null> {
+  if (isSupabaseConfigured) {
+    return validateApiToken(token)
+  }
+  return token === AUTH_TOKEN ? "relay-user" : null
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,31 @@
+import crypto from "node:crypto"
+import type { RequestHandler } from "express"
+
+export const AUTH_TOKEN =
+  process.env.MCP_AUTH_TOKEN || crypto.randomBytes(24).toString("hex")
+
+export const headerAuth: RequestHandler = (req, res, next) => {
+  const header = req.headers.authorization
+  if (header === `Bearer ${AUTH_TOKEN}`) {
+    next()
+    return
+  }
+
+  res.status(401).json({ error: "Unauthorized" })
+}
+
+export const headerOrQueryAuth: RequestHandler = (req, res, next) => {
+  const header = req.headers.authorization
+  if (header === `Bearer ${AUTH_TOKEN}`) {
+    next()
+    return
+  }
+
+  const token = req.query.token
+  if (token === AUTH_TOKEN) {
+    next()
+    return
+  }
+
+  res.status(401).json({ error: "Unauthorized" })
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,20 @@
+import express from "express"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { createMcpServer } from "./mcp.js"
+import relayRouter from "./relay.js"
+import { AUTH_TOKEN } from "./auth.js"
+
+const relayPort = parseInt(process.env.MCP_RELAY_PORT || "3001", 10)
+
+const relayApp = express()
+relayApp.use(express.json())
+relayApp.use(relayRouter)
+
+relayApp.listen(relayPort, () => {
+  console.error(`[MCP Relay] Listening on http://localhost:${relayPort}`)
+  console.error(`[MCP Relay] Auth token: ${AUTH_TOKEN}`)
+})
+
+const mcpServer = createMcpServer()
+const transport = new StdioServerTransport()
+await mcpServer.connect(transport)

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,18 +2,24 @@ import express from "express"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createMcpServer } from "./mcp.js"
 import relayRouter from "./relay.js"
-import { AUTH_TOKEN } from "./auth.js"
+import { isSupabaseConfigured } from "./supabase.js"
 
-const relayPort = parseInt(process.env.MCP_RELAY_PORT || "3001", 10)
+const mode = isSupabaseConfigured && process.env.WHATTODO_API_TOKEN
+  ? "supabase"
+  : "relay"
 
-const relayApp = express()
-relayApp.use(express.json())
-relayApp.use(relayRouter)
-
-relayApp.listen(relayPort, () => {
-  console.error(`[MCP Relay] Listening on http://localhost:${relayPort}`)
-  console.error(`[MCP Relay] Auth token: ${AUTH_TOKEN}`)
-})
+if (mode === "relay") {
+  const relayPort = parseInt(process.env.MCP_RELAY_PORT || "3001", 10)
+  const relayApp = express()
+  relayApp.use(express.json())
+  relayApp.use(relayRouter)
+  relayApp.listen(relayPort, () => {
+    console.error(`[MCP] Mode: relay — open the What Todo app in your browser`)
+    console.error(`[MCP Relay] Listening on http://localhost:${relayPort}`)
+  })
+} else {
+  console.error(`[MCP] Mode: supabase — reading/writing directly to the database`)
+}
 
 const mcpServer = createMcpServer()
 const transport = new StdioServerTransport()

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
-import { isBrowserConnected, sendCommand } from "./relay.js"
+import { executeTool } from "./storage.js"
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -8,55 +8,32 @@ export function createMcpServer(): McpServer {
     version: "1.0.0",
   })
 
-  function relayTool(tool: string, params: Record<string, unknown>) {
-    if (!isBrowserConnected()) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: "Error: No browser connected. Please open the What Todo app in your browser first.",
-          },
-        ],
-        isError: true,
-      }
-    }
-
-    return sendCommand(tool, params).then((response) => {
-      if (!response.success) {
-        return {
-          content: [
-            { type: "text" as const, text: `Error: ${response.error}` },
-          ],
-          isError: true,
-        }
-      }
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2),
-          },
-        ],
-      }
-    })
+  const tool = (
+    name: string,
+    description: string,
+    schema: Record<string, z.ZodTypeAny>,
+    handler: (params: Record<string, unknown>) => Record<string, unknown>
+  ) => {
+    server.tool(name, description, schema, async (params) =>
+      executeTool(name, handler(params))
+    )
   }
 
-  server.tool(
+  tool(
     "list_todos",
     "List current todos. Returns all uncompleted tasks by default.",
     { include_completed: z.boolean().optional().describe("Include completed tasks. Defaults to false.") },
-    async ({ include_completed }) => relayTool("list_todos", { include_completed }),
+    (p) => p
   )
 
-  server.tool(
+  tool(
     "list_labels",
     "List all available labels with their id, title, and color.",
     {},
-    async () => relayTool("list_labels", {}),
+    (p) => p
   )
 
-  server.tool(
+  tool(
     "add_todo",
     "Add a new todo task to today's list.",
     {
@@ -65,20 +42,20 @@ export function createMcpServer(): McpServer {
       labels: z.array(z.string()).optional().describe("Optional array of label IDs to attach"),
       pinned: z.boolean().optional().describe("Whether to pin the task. Defaults to false."),
     },
-    async (params) => relayTool("add_todo", params),
+    (p) => p
   )
 
-  server.tool(
+  tool(
     "complete_todo",
     "Mark a todo as completed. Provide either id or title to find the task.",
     {
       id: z.string().optional().describe("Task ID (exact match)"),
       title: z.string().optional().describe("Task title (case-insensitive substring match)"),
     },
-    async (params) => relayTool("complete_todo", params),
+    (p) => p
   )
 
-  server.tool(
+  tool(
     "pin_todo",
     "Pin or unpin a todo. Provide either id or title to find the task.",
     {
@@ -86,20 +63,20 @@ export function createMcpServer(): McpServer {
       title: z.string().optional().describe("Task title (case-insensitive substring match)"),
       pinned: z.boolean().optional().describe("Whether to pin (true) or unpin (false). Defaults to true."),
     },
-    async (params) => relayTool("pin_todo", { ...params, pinned: params.pinned ?? true }),
+    (p) => ({ ...p, pinned: (p.pinned as boolean) ?? true })
   )
 
-  server.tool(
+  tool(
     "create_label",
     "Create a new label for categorizing todos.",
     {
       title: z.string().describe("Label title"),
       color: z.string().optional().describe("Hex color (e.g. '#ff0000'). Random color if omitted."),
     },
-    async (params) => relayTool("create_label", params),
+    (p) => p
   )
 
-  server.tool(
+  tool(
     "label_todo",
     "Add a label to a todo. Both task and label can be matched by ID or title.",
     {
@@ -108,7 +85,7 @@ export function createMcpServer(): McpServer {
       label_id: z.string().optional().describe("Label ID (exact match)"),
       label_title: z.string().optional().describe("Label title (case-insensitive substring match)"),
     },
-    async (params) => relayTool("label_todo", params),
+    (p) => p
   )
 
   return server

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -1,0 +1,115 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+import { isBrowserConnected, sendCommand } from "./relay.js"
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "what-todo",
+    version: "1.0.0",
+  })
+
+  function relayTool(tool: string, params: Record<string, unknown>) {
+    if (!isBrowserConnected()) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Error: No browser connected. Please open the What Todo app in your browser first.",
+          },
+        ],
+        isError: true,
+      }
+    }
+
+    return sendCommand(tool, params).then((response) => {
+      if (!response.success) {
+        return {
+          content: [
+            { type: "text" as const, text: `Error: ${response.error}` },
+          ],
+          isError: true,
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(response.data, null, 2),
+          },
+        ],
+      }
+    })
+  }
+
+  server.tool(
+    "list_todos",
+    "List current todos. Returns all uncompleted tasks by default.",
+    { include_completed: z.boolean().optional().describe("Include completed tasks. Defaults to false.") },
+    async ({ include_completed }) => relayTool("list_todos", { include_completed }),
+  )
+
+  server.tool(
+    "list_labels",
+    "List all available labels with their id, title, and color.",
+    {},
+    async () => relayTool("list_labels", {}),
+  )
+
+  server.tool(
+    "add_todo",
+    "Add a new todo task to today's list.",
+    {
+      title: z.string().describe("The task title"),
+      description: z.string().optional().describe("Optional task description"),
+      labels: z.array(z.string()).optional().describe("Optional array of label IDs to attach"),
+      pinned: z.boolean().optional().describe("Whether to pin the task. Defaults to false."),
+    },
+    async (params) => relayTool("add_todo", params),
+  )
+
+  server.tool(
+    "complete_todo",
+    "Mark a todo as completed. Provide either id or title to find the task.",
+    {
+      id: z.string().optional().describe("Task ID (exact match)"),
+      title: z.string().optional().describe("Task title (case-insensitive substring match)"),
+    },
+    async (params) => relayTool("complete_todo", params),
+  )
+
+  server.tool(
+    "pin_todo",
+    "Pin or unpin a todo. Provide either id or title to find the task.",
+    {
+      id: z.string().optional().describe("Task ID (exact match)"),
+      title: z.string().optional().describe("Task title (case-insensitive substring match)"),
+      pinned: z.boolean().optional().describe("Whether to pin (true) or unpin (false). Defaults to true."),
+    },
+    async (params) => relayTool("pin_todo", { ...params, pinned: params.pinned ?? true }),
+  )
+
+  server.tool(
+    "create_label",
+    "Create a new label for categorizing todos.",
+    {
+      title: z.string().describe("Label title"),
+      color: z.string().optional().describe("Hex color (e.g. '#ff0000'). Random color if omitted."),
+    },
+    async (params) => relayTool("create_label", params),
+  )
+
+  server.tool(
+    "label_todo",
+    "Add a label to a todo. Both task and label can be matched by ID or title.",
+    {
+      task_id: z.string().optional().describe("Task ID (exact match)"),
+      task_title: z.string().optional().describe("Task title (case-insensitive substring match)"),
+      label_id: z.string().optional().describe("Label ID (exact match)"),
+      label_title: z.string().optional().describe("Label title (case-insensitive substring match)"),
+    },
+    async (params) => relayTool("label_todo", params),
+  )
+
+  return server
+}

--- a/server/relay.ts
+++ b/server/relay.ts
@@ -1,0 +1,102 @@
+import crypto from "node:crypto"
+import { Router } from "express"
+import { z } from "zod"
+import { headerAuth, headerOrQueryAuth } from "./auth.js"
+import type { RelayCommand, RelayResponse } from "./types.js"
+import type { Response } from "express"
+
+const RelayResponseSchema = z.object({
+  id: z.string(),
+  success: z.boolean(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+})
+
+const router = Router()
+
+let browserResponse: Response | null = null
+
+const pendingCommands = new Map<
+  string,
+  { resolve: (response: RelayResponse) => void; timeout: NodeJS.Timeout }
+>()
+
+export function isBrowserConnected(): boolean {
+  return browserResponse !== null
+}
+
+export function sendCommand(
+  tool: string,
+  params: Record<string, unknown>,
+): Promise<RelayResponse> {
+  if (!browserResponse) {
+    return Promise.resolve({
+      id: "",
+      success: false,
+      error:
+        "No browser connected. Please open the What Todo app in your browser first.",
+    })
+  }
+
+  const command: RelayCommand = {
+    id: crypto.randomUUID(),
+    tool,
+    params,
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      pendingCommands.delete(command.id)
+      resolve({ id: command.id, success: false, error: "Command timed out" })
+    }, 10_000)
+
+    pendingCommands.set(command.id, { resolve, timeout })
+
+    browserResponse!.write(`data: ${JSON.stringify(command)}\n\n`)
+  })
+}
+
+router.get("/relay/events", headerOrQueryAuth, (req, res) => {
+  res.setHeader("Content-Type", "text/event-stream")
+  res.setHeader("Cache-Control", "no-cache")
+  res.setHeader("Connection", "keep-alive")
+  res.flushHeaders()
+
+  if (browserResponse) {
+    browserResponse.end()
+  }
+
+  browserResponse = res
+
+  const heartbeat = setInterval(() => {
+    res.write(": heartbeat\n\n")
+  }, 30_000)
+
+  req.on("close", () => {
+    clearInterval(heartbeat)
+    if (browserResponse === res) {
+      browserResponse = null
+    }
+  })
+})
+
+router.post("/relay/respond", headerAuth, (req, res) => {
+  const result = RelayResponseSchema.safeParse(req.body)
+  if (!result.success) {
+    res.status(400).json({ error: "Invalid response body" })
+    return
+  }
+
+  const response: RelayResponse = result.data
+
+  const pending = pendingCommands.get(response.id)
+  if (pending) {
+    clearTimeout(pending.timeout)
+    pending.resolve(response)
+    pendingCommands.delete(response.id)
+  }
+
+  res.json({ ok: true })
+})
+
+export default router

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,0 +1,185 @@
+import { Data, Task, Label } from "../src/index.d"
+import { getData, setData, validateApiToken, isSupabaseConfigured } from "./supabase.js"
+import { isBrowserConnected, sendCommand } from "./relay.js"
+
+const COLORS = [
+  "#ef4444", "#f97316", "#eab308", "#22c55e",
+  "#14b8a6", "#3b82f6", "#8b5cf6", "#ec4899",
+]
+
+function uuid() {
+  return crypto.randomUUID()
+}
+
+function todayKey() {
+  return new Date().toDateString()
+}
+
+function findTask(data: Data, id?: string, title?: string): Task | undefined {
+  const all = Object.values(data.tasks).flat()
+  if (id) return all.find(t => t.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return all.find(t => t.title.toLowerCase().includes(lower))
+  }
+}
+
+function findLabel(data: Data, id?: string, title?: string): Label | undefined {
+  if (id) return data.labels.find(l => l.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return data.labels.find(l => l.title.toLowerCase().includes(lower))
+  }
+}
+
+function defaultData(): Data {
+  return {
+    schemaVersion: 1,
+    migrated: true,
+    filters: [],
+    tasks: {},
+    labels: [],
+    sections: {
+      completed: { collapsed: true },
+      focus: {},
+      sidebar: { collapsed: false }
+    }
+  }
+}
+
+export type ToolResult = {
+  content: { type: "text"; text: string }[]
+  isError?: boolean
+}
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] }
+}
+
+function err(message: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true }
+}
+
+/**
+ * Execute a tool operation directly against Supabase.
+ * Requires WHATTODO_API_TOKEN to be validated first.
+ */
+export async function executeSupabase(
+  apiToken: string,
+  tool: string,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const userId = await validateApiToken(apiToken)
+  if (!userId) return err("Invalid API token")
+
+  const data = (await getData(userId)) ?? defaultData()
+
+  switch (tool) {
+    case "list_todos": {
+      const includeCompleted = params.include_completed as boolean | undefined
+      const all = Object.values(data.tasks).flat()
+      const tasks = includeCompleted ? all : all.filter(t => !t.completed)
+      return ok(tasks.map(t => ({
+        id: t.id, title: t.title, description: t.description,
+        completed: t.completed, pinned: t.pinned, labels: t.labels,
+        created_at: t.created_at,
+      })))
+    }
+
+    case "list_labels":
+      return ok(data.labels)
+
+    case "add_todo": {
+      const key = todayKey()
+      const task: Task = {
+        id: uuid(),
+        title: params.title as string,
+        description: (params.description as string) || undefined,
+        labels: (params.labels as string[]) || [],
+        pinned: (params.pinned as boolean) || false,
+        completed: false,
+        created_at: new Date().toISOString(),
+      }
+      data.tasks[key] = [task, ...(data.tasks[key] || [])]
+      await setData(userId, data)
+      return ok({ message: `Added todo: ${task.title}` })
+    }
+
+    case "complete_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return err("Task not found")
+      task.completed = true
+      task.completed_at = new Date().toISOString()
+      await setData(userId, data)
+      return ok({ message: `Completed: ${task.title}` })
+    }
+
+    case "pin_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return err("Task not found")
+      task.pinned = (params.pinned as boolean) ?? true
+      await setData(userId, data)
+      return ok({ message: `${task.pinned ? "Pinned" : "Unpinned"}: ${task.title}` })
+    }
+
+    case "create_label": {
+      const existing = data.labels.find(
+        l => l.title.toLowerCase() === (params.title as string).toLowerCase()
+      )
+      if (existing) return ok({ message: `Label already exists: ${existing.title}` })
+      const label: Label = {
+        id: uuid(),
+        title: params.title as string,
+        color: (params.color as string) || COLORS[Math.floor(Math.random() * COLORS.length)],
+      }
+      data.labels.push(label)
+      await setData(userId, data)
+      return ok({ message: `Created label: ${label.title}` })
+    }
+
+    case "label_todo": {
+      const task = findTask(data, params.task_id as string, params.task_title as string)
+      if (!task) return err("Task not found")
+      const label = findLabel(data, params.label_id as string, params.label_title as string)
+      if (!label) return err("Label not found")
+      task.labels = [...new Set([...(task.labels || []), label.id])]
+      await setData(userId, data)
+      return ok({ message: `Added label "${label.title}" to "${task.title}"` })
+    }
+
+    default:
+      return err(`Unknown tool: ${tool}`)
+  }
+}
+
+/**
+ * Execute a tool via the browser relay (localStorage users).
+ */
+export async function executeRelay(
+  tool: string,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  if (!isBrowserConnected()) {
+    return err("No browser connected. Open the What Todo app in your browser first.")
+  }
+
+  const response = await sendCommand(tool, params)
+  if (!response.success) return err(response.error ?? "Unknown error")
+  return ok(response.data)
+}
+
+/**
+ * Route to Supabase or relay based on available config and env.
+ */
+export async function executeTool(
+  tool: string,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const apiToken = process.env.WHATTODO_API_TOKEN
+
+  if (isSupabaseConfigured && apiToken) {
+    return executeSupabase(apiToken, tool, params)
+  }
+
+  return executeRelay(tool, params)
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,64 +1,8 @@
-import { Data, Task, Label } from "../src/index.d"
 import { getData, setData, validateApiToken, isSupabaseConfigured } from "./supabase.js"
 import { isBrowserConnected, sendCommand } from "./relay.js"
+import { executeToolOnData, defaultData, type ToolResult } from "./tools.js"
 
-const COLORS = [
-  "#ef4444", "#f97316", "#eab308", "#22c55e",
-  "#14b8a6", "#3b82f6", "#8b5cf6", "#ec4899",
-]
-
-function uuid() {
-  return crypto.randomUUID()
-}
-
-function todayKey() {
-  return new Date().toDateString()
-}
-
-function findTask(data: Data, id?: string, title?: string): Task | undefined {
-  const all = Object.values(data.tasks).flat()
-  if (id) return all.find(t => t.id === id)
-  if (title) {
-    const lower = title.toLowerCase()
-    return all.find(t => t.title.toLowerCase().includes(lower))
-  }
-}
-
-function findLabel(data: Data, id?: string, title?: string): Label | undefined {
-  if (id) return data.labels.find(l => l.id === id)
-  if (title) {
-    const lower = title.toLowerCase()
-    return data.labels.find(l => l.title.toLowerCase().includes(lower))
-  }
-}
-
-function defaultData(): Data {
-  return {
-    schemaVersion: 1,
-    migrated: true,
-    filters: [],
-    tasks: {},
-    labels: [],
-    sections: {
-      completed: { collapsed: true },
-      focus: {},
-      sidebar: { collapsed: false }
-    }
-  }
-}
-
-export type ToolResult = {
-  content: { type: "text"; text: string }[]
-  isError?: boolean
-}
-
-function ok(data: unknown): ToolResult {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] }
-}
-
-function err(message: string): ToolResult {
-  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true }
-}
+export type { ToolResult }
 
 /**
  * Execute a tool operation directly against Supabase.
@@ -70,86 +14,12 @@ export async function executeSupabase(
   params: Record<string, unknown>
 ): Promise<ToolResult> {
   const userId = await validateApiToken(apiToken)
-  if (!userId) return err("Invalid API token")
+  if (!userId) return { content: [{ type: "text", text: "Error: Invalid API token" }], isError: true }
 
   const data = (await getData(userId)) ?? defaultData()
-
-  switch (tool) {
-    case "list_todos": {
-      const includeCompleted = params.include_completed as boolean | undefined
-      const all = Object.values(data.tasks).flat()
-      const tasks = includeCompleted ? all : all.filter(t => !t.completed)
-      return ok(tasks.map(t => ({
-        id: t.id, title: t.title, description: t.description,
-        completed: t.completed, pinned: t.pinned, labels: t.labels,
-        created_at: t.created_at,
-      })))
-    }
-
-    case "list_labels":
-      return ok(data.labels)
-
-    case "add_todo": {
-      const key = todayKey()
-      const task: Task = {
-        id: uuid(),
-        title: params.title as string,
-        description: (params.description as string) || undefined,
-        labels: (params.labels as string[]) || [],
-        pinned: (params.pinned as boolean) || false,
-        completed: false,
-        created_at: new Date().toISOString(),
-      }
-      data.tasks[key] = [task, ...(data.tasks[key] || [])]
-      await setData(userId, data)
-      return ok({ message: `Added todo: ${task.title}` })
-    }
-
-    case "complete_todo": {
-      const task = findTask(data, params.id as string, params.title as string)
-      if (!task) return err("Task not found")
-      task.completed = true
-      task.completed_at = new Date().toISOString()
-      await setData(userId, data)
-      return ok({ message: `Completed: ${task.title}` })
-    }
-
-    case "pin_todo": {
-      const task = findTask(data, params.id as string, params.title as string)
-      if (!task) return err("Task not found")
-      task.pinned = (params.pinned as boolean) ?? true
-      await setData(userId, data)
-      return ok({ message: `${task.pinned ? "Pinned" : "Unpinned"}: ${task.title}` })
-    }
-
-    case "create_label": {
-      const existing = data.labels.find(
-        l => l.title.toLowerCase() === (params.title as string).toLowerCase()
-      )
-      if (existing) return ok({ message: `Label already exists: ${existing.title}` })
-      const label: Label = {
-        id: uuid(),
-        title: params.title as string,
-        color: (params.color as string) || COLORS[Math.floor(Math.random() * COLORS.length)],
-      }
-      data.labels.push(label)
-      await setData(userId, data)
-      return ok({ message: `Created label: ${label.title}` })
-    }
-
-    case "label_todo": {
-      const task = findTask(data, params.task_id as string, params.task_title as string)
-      if (!task) return err("Task not found")
-      const label = findLabel(data, params.label_id as string, params.label_title as string)
-      if (!label) return err("Label not found")
-      task.labels = [...new Set([...(task.labels || []), label.id])]
-      await setData(userId, data)
-      return ok({ message: `Added label "${label.title}" to "${task.title}"` })
-    }
-
-    default:
-      return err(`Unknown tool: ${tool}`)
-  }
+  const { result, mutated } = executeToolOnData(data, tool, params)
+  if (mutated) await setData(userId, data)
+  return result
 }
 
 /**
@@ -160,12 +30,20 @@ export async function executeRelay(
   params: Record<string, unknown>
 ): Promise<ToolResult> {
   if (!isBrowserConnected()) {
-    return err("No browser connected. Open the What Todo app in your browser first.")
+    return {
+      content: [{ type: "text", text: "Error: No browser connected. Open the What Todo app in your browser first." }],
+      isError: true,
+    }
   }
 
   const response = await sendCommand(tool, params)
-  if (!response.success) return err(response.error ?? "Unknown error")
-  return ok(response.data)
+  if (!response.success) {
+    return {
+      content: [{ type: "text", text: `Error: ${response.error ?? "Unknown error"}` }],
+      isError: true,
+    }
+  }
+  return { content: [{ type: "text", text: JSON.stringify(response.data, null, 2) }] }
 }
 
 /**

--- a/server/supabase.ts
+++ b/server/supabase.ts
@@ -1,0 +1,65 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
+import { Data } from "../src/index.d"
+
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+export const isSupabaseConfigured = !!(SUPABASE_URL && SERVICE_ROLE_KEY)
+
+let _client: SupabaseClient | null = null
+
+function getClient(): SupabaseClient {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    throw new Error(
+      "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set for Supabase mode"
+    )
+  }
+  if (!_client) {
+    _client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+      auth: { persistSession: false }
+    })
+  }
+  return _client
+}
+
+/**
+ * Validate an API token and return the user's ID, or null if invalid.
+ */
+export async function validateApiToken(token: string): Promise<string | null> {
+  const { data, error } = await getClient()
+    .from("users")
+    .select("id")
+    .eq("api_token", token)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return data.id as string
+}
+
+/**
+ * Read the full data blob for a user.
+ */
+export async function getData(userId: string): Promise<Data | null> {
+  const { data, error } = await getClient()
+    .from("todos")
+    .select("data")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read todos: ${error.message}`)
+  return (data?.data as Data) ?? null
+}
+
+/**
+ * Write the full data blob for a user.
+ */
+export async function setData(userId: string, newData: Data): Promise<void> {
+  const { error } = await getClient()
+    .from("todos")
+    .upsert(
+      { user_id: userId, data: newData, updated_at: new Date().toISOString() },
+      { onConflict: "user_id" }
+    )
+
+  if (error) throw new Error(`Failed to write todos: ${error.message}`)
+}

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -1,0 +1,144 @@
+import { Data, Task, Label } from "../src/index.d"
+
+const COLORS = [
+  "#ef4444", "#f97316", "#eab308", "#22c55e",
+  "#14b8a6", "#3b82f6", "#8b5cf6", "#ec4899",
+]
+
+export type ToolResult = {
+  content: { type: "text"; text: string }[]
+  isError?: boolean
+}
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] }
+}
+
+function err(message: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true }
+}
+
+function uuid() {
+  return crypto.randomUUID()
+}
+
+function todayKey() {
+  return new Date().toDateString()
+}
+
+function findTask(data: Data, id?: string, title?: string): Task | undefined {
+  const all = Object.values(data.tasks).flat()
+  if (id) return all.find(t => t.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return all.find(t => t.title.toLowerCase().includes(lower))
+  }
+}
+
+function findLabel(data: Data, id?: string, title?: string): Label | undefined {
+  if (id) return data.labels.find(l => l.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return data.labels.find(l => l.title.toLowerCase().includes(lower))
+  }
+}
+
+export function defaultData(): Data {
+  return {
+    schemaVersion: 1,
+    migrated: true,
+    filters: [],
+    tasks: {},
+    labels: [],
+    sections: {
+      completed: { collapsed: true },
+      focus: {},
+      sidebar: { collapsed: false },
+    },
+  }
+}
+
+/**
+ * Apply a tool operation to an in-memory Data object.
+ * Returns the result and a boolean indicating whether the data was mutated
+ * (so callers can decide whether to persist).
+ */
+export function executeToolOnData(
+  data: Data,
+  tool: string,
+  params: Record<string, unknown>
+): { result: ToolResult; mutated: boolean } {
+  const r = (result: ToolResult, mutated = false) => ({ result, mutated })
+
+  switch (tool) {
+    case "list_todos": {
+      const includeCompleted = params.include_completed as boolean | undefined
+      const all = Object.values(data.tasks).flat()
+      const tasks = includeCompleted ? all : all.filter(t => !t.completed)
+      return r(ok(tasks.map(t => ({
+        id: t.id, title: t.title, description: t.description,
+        completed: t.completed, pinned: t.pinned, labels: t.labels,
+        created_at: t.created_at,
+      }))))
+    }
+
+    case "list_labels":
+      return r(ok(data.labels))
+
+    case "add_todo": {
+      const key = todayKey()
+      const task: Task = {
+        id: uuid(),
+        title: params.title as string,
+        description: (params.description as string) || undefined,
+        labels: (params.labels as string[]) || [],
+        pinned: (params.pinned as boolean) || false,
+        completed: false,
+        created_at: new Date().toISOString(),
+      }
+      data.tasks[key] = [task, ...(data.tasks[key] || [])]
+      return r(ok({ message: `Added todo: ${task.title}` }), true)
+    }
+
+    case "complete_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return r(err("Task not found"))
+      task.completed = true
+      task.completed_at = new Date().toISOString()
+      return r(ok({ message: `Completed: ${task.title}` }), true)
+    }
+
+    case "pin_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return r(err("Task not found"))
+      task.pinned = (params.pinned as boolean) ?? true
+      return r(ok({ message: `${task.pinned ? "Pinned" : "Unpinned"}: ${task.title}` }), true)
+    }
+
+    case "create_label": {
+      const existing = data.labels.find(
+        l => l.title.toLowerCase() === (params.title as string).toLowerCase()
+      )
+      if (existing) return r(ok({ message: `Label already exists: ${existing.title}` }))
+      const label: Label = {
+        id: uuid(),
+        title: params.title as string,
+        color: (params.color as string) || COLORS[Math.floor(Math.random() * COLORS.length)],
+      }
+      data.labels.push(label)
+      return r(ok({ message: `Created label: ${label.title}` }), true)
+    }
+
+    case "label_todo": {
+      const task = findTask(data, params.task_id as string, params.task_title as string)
+      if (!task) return r(err("Task not found"))
+      const label = findLabel(data, params.label_id as string, params.label_title as string)
+      if (!label) return r(err("Label not found"))
+      task.labels = [...new Set([...(task.labels || []), label.id])]
+      return r(ok({ message: `Added label "${label.title}" to "${task.title}"` }), true)
+    }
+
+    default:
+      return r(err(`Unknown tool: ${tool}`))
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,12 @@
+export interface RelayCommand {
+  id: string
+  tool: string
+  params: Record<string, unknown>
+}
+
+export interface RelayResponse {
+  id: string
+  success: boolean
+  data?: unknown
+  error?: string
+}

--- a/src/adapters/LocalStorageAdapter.ts
+++ b/src/adapters/LocalStorageAdapter.ts
@@ -1,7 +1,7 @@
 import { Data } from "../index.d"
 import { StorageAdapter } from "./StorageAdapter"
 
-const STORAGE_KEY = "what-todo"
+export const STORAGE_KEY = "what-todo"
 
 /**
  * Stores data in the browser's localStorage as a single JSON blob.

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -199,11 +199,13 @@ const List: React.FC<Props> = ({
 
   const [localOrder, setLocalOrder] = React.useState(uncompleted)
 
-  const uncompletedIds = uncompleted.map(t => t.id).join(",")
+  const uncompletedKey = uncompleted
+    .map(t => `${t.id}:${t.pinned}:${t.labels?.join("|")}`)
+    .join(",")
   React.useEffect(() => {
     setLocalOrder(uncompleted)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uncompletedIds])
+  }, [uncompletedKey])
 
   const handleReorder = (reordered: TaskType[]) => {
     setLocalOrder(reordered)

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -100,7 +100,28 @@ const Task: React.FC<Props> = ({
 }) => {
   const { settings } = useSettings()
   const ref = useRef<HTMLDivElement>(null)
-  const [state, setState] = React.useState<TaskType | undefined>(task)
+  const [localState, setLocalState] = React.useState<TaskType | undefined>(task)
+  const prevTaskRef = React.useRef<TaskType>(task)
+
+  // When the task prop changes externally, sync only the fields that changed
+  // from the outside — preserving any in-progress local edits.
+  if (prevTaskRef.current !== task) {
+    const prev = prevTaskRef.current
+    prevTaskRef.current = task
+    if (localState) {
+      const patch: Partial<TaskType> = {}
+      if (prev.pinned !== task.pinned) patch.pinned = task.pinned
+      if (prev.completed !== task.completed) patch.completed = task.completed
+      if (prev.labels?.join(",") !== task.labels?.join(","))
+        patch.labels = task.labels
+      if (Object.keys(patch).length > 0) {
+        setLocalState({ ...localState, ...patch })
+      }
+    }
+  }
+
+  const state = localState
+  const setState = (t: TaskType | undefined) => setLocalState(t)
   const descriptionURL = getDescriptionURL(state?.description)
   const [, setHovering] = React.useState<boolean>(false)
   const [glowing, setGlowing] = React.useState(false)

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -103,8 +103,10 @@ const Task: React.FC<Props> = ({
   const [localState, setLocalState] = React.useState<TaskType | undefined>(task)
   const prevTaskRef = React.useRef<TaskType>(task)
 
-  // When the task prop changes externally, sync only the fields that changed
-  // from the outside — preserving any in-progress local edits.
+  // Derived state during render: when the task prop changes externally, sync
+  // only the fields that differ — preserving any in-progress local edits.
+  // Calling setState here (not in an effect) is intentional per React docs:
+  // React re-renders immediately and the stale render output is discarded.
   if (prevTaskRef.current !== task) {
     const prev = prevTaskRef.current
     prevTaskRef.current = task

--- a/src/hooks/useMCPRelay.ts
+++ b/src/hooks/useMCPRelay.ts
@@ -1,5 +1,10 @@
 import type { Data, Task, Label } from "../index.d"
-import { notifyStorageUpdate, STORAGE_KEY } from "../context/StorageContext"
+import { STORAGE_KEY } from "../adapters/LocalStorageAdapter"
+
+function notifyStorageUpdate() {
+  // Dispatch a storage event so StorageContext re-reads from localStorage
+  window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }))
+}
 
 interface RelayCommand {
   id: string

--- a/src/hooks/useMCPRelay.ts
+++ b/src/hooks/useMCPRelay.ts
@@ -1,0 +1,252 @@
+import type { Data, Task, Label } from "../index.d"
+import { notifyStorageUpdate, STORAGE_KEY } from "../context/StorageContext"
+
+interface RelayCommand {
+  id: string
+  tool: string
+  params: Record<string, unknown>
+}
+
+const RELAY_TOKEN = import.meta.env.VITE_MCP_RELAY_TOKEN as string
+
+const COLORS = [
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#14b8a6",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899"
+]
+
+const defaultData: Data = {
+  migrated: true,
+  filters: [],
+  tasks: {},
+  labels: [],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false }
+  }
+}
+
+function read(): Data {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return defaultData
+  try {
+    return JSON.parse(raw) as Data
+  } catch {
+    return defaultData
+  }
+}
+
+declare global {
+  interface Window {
+    __mcpRelayEventSource?: EventSource
+  }
+}
+
+function write(data: Data) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  notifyStorageUpdate()
+}
+
+function uuid() {
+  return crypto.randomUUID()
+}
+
+function todayKey() {
+  return new Date().toDateString()
+}
+
+function findTask(data: Data, id?: string, title?: string): Task | undefined {
+  const allTasks = Object.values(data.tasks).flat()
+  if (id) return allTasks.find(t => t.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return allTasks.find(t => t.title.toLowerCase().includes(lower))
+  }
+  return undefined
+}
+
+function findLabel(data: Data, id?: string, title?: string): Label | undefined {
+  if (id) return data.labels.find(l => l.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return data.labels.find(l => l.title.toLowerCase().includes(lower))
+  }
+  return undefined
+}
+
+function executeCommand(command: RelayCommand): {
+  success: boolean
+  data?: unknown
+  error?: string
+} {
+  const { tool, params } = command
+  const data = read()
+
+  switch (tool) {
+    case "list_todos": {
+      const includeCompleted = params.include_completed as boolean | undefined
+      const allTasks = Object.values(data.tasks).flat()
+      const tasks = includeCompleted
+        ? allTasks
+        : allTasks.filter(t => !t.completed)
+      return {
+        success: true,
+        data: tasks.map(t => ({
+          id: t.id,
+          title: t.title,
+          description: t.description,
+          completed: t.completed,
+          pinned: t.pinned,
+          labels: t.labels,
+          created_at: t.created_at
+        }))
+      }
+    }
+
+    case "list_labels": {
+      return { success: true, data: data.labels }
+    }
+
+    case "add_todo": {
+      const key = todayKey()
+      const task: Task = {
+        id: uuid(),
+        title: params.title as string,
+        description: (params.description as string) || undefined,
+        labels: (params.labels as string[]) || [],
+        pinned: (params.pinned as boolean) || false,
+        completed: false,
+        created_at: new Date().toISOString()
+      }
+      data.tasks[key] = [task, ...(data.tasks[key] || [])]
+      write(data)
+      return { success: true, data: { message: `Added todo: ${task.title}` } }
+    }
+
+    case "complete_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return { success: false, error: "Task not found" }
+      task.completed = true
+      task.completed_at = new Date().toISOString()
+      write(data)
+      return { success: true, data: { message: `Completed: ${task.title}` } }
+    }
+
+    case "pin_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return { success: false, error: "Task not found" }
+      task.pinned = (params.pinned as boolean) ?? true
+      write(data)
+      return {
+        success: true,
+        data: {
+          message: `${task.pinned ? "Pinned" : "Unpinned"}: ${task.title}`
+        }
+      }
+    }
+
+    case "create_label": {
+      const existing = data.labels.find(
+        l => l.title.toLowerCase() === (params.title as string).toLowerCase()
+      )
+      if (existing) {
+        return {
+          success: true,
+          data: { message: `Label already exists: ${existing.title}` }
+        }
+      }
+      const color =
+        (params.color as string) ||
+        COLORS[Math.floor(Math.random() * COLORS.length)]
+      const label: Label = {
+        id: uuid(),
+        title: params.title as string,
+        color
+      }
+      data.labels.push(label)
+      write(data)
+      return {
+        success: true,
+        data: { message: `Created label: ${label.title}` }
+      }
+    }
+
+    case "label_todo": {
+      const task = findTask(
+        data,
+        params.task_id as string,
+        params.task_title as string
+      )
+      if (!task) return { success: false, error: "Task not found" }
+      const label = findLabel(
+        data,
+        params.label_id as string,
+        params.label_title as string
+      )
+      if (!label) return { success: false, error: "Label not found" }
+      task.labels = [...new Set([...(task.labels || []), label.id])]
+      write(data)
+      return {
+        success: true,
+        data: {
+          message: `Added label "${label.title}" to "${task.title}"`
+        }
+      }
+    }
+
+    default:
+      return { success: false, error: `Unknown tool: ${tool}` }
+  }
+}
+
+declare global {
+  interface Window {
+    __mcpRelayEventSource?: EventSource
+  }
+}
+
+if (RELAY_TOKEN && !window.__mcpRelayEventSource) {
+  const url = `/relay/events?token=${RELAY_TOKEN}`
+  const eventSource = new EventSource(url)
+  window.__mcpRelayEventSource = eventSource
+
+  let queue: Promise<void> = Promise.resolve()
+
+  eventSource.onmessage = event => {
+    const command: RelayCommand = JSON.parse(event.data)
+
+    queue = queue.then(async () => {
+      let result: { success: boolean; data?: unknown; error?: string }
+
+      try {
+        result = executeCommand(command)
+      } catch (err) {
+        result = {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error"
+        }
+      }
+
+      await fetch("/relay/respond", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${RELAY_TOKEN}`
+        },
+        body: JSON.stringify({ id: command.id, ...result })
+      })
+    })
+  }
+
+  eventSource.onerror = () => {
+    console.warn("[MCP Relay] SSE connection error, will retry...")
+  }
+}
+
+export function useMCPRelay() {}

--- a/src/hooks/useMCPRelay.ts
+++ b/src/hooks/useMCPRelay.ts
@@ -26,6 +26,7 @@ const COLORS = [
 ]
 
 const defaultData: Data = {
+  schemaVersion: 1,
   migrated: true,
   filters: [],
   tasks: {},
@@ -44,12 +45,6 @@ function read(): Data {
     return JSON.parse(raw) as Data
   } catch {
     return defaultData
-  }
-}
-
-declare global {
-  interface Window {
-    __mcpRelayEventSource?: EventSource
   }
 }
 
@@ -216,7 +211,11 @@ declare global {
   }
 }
 
-if (RELAY_TOKEN && !window.__mcpRelayEventSource) {
+export function initMCPRelay() {
+  if (!RELAY_TOKEN || window.__mcpRelayEventSource) return
+
+  // EventSource doesn't support custom headers, so the token is passed as a
+  // query param. This is local-dev only — the relay is never exposed publicly.
   const url = `/relay/events?token=${RELAY_TOKEN}`
   const eventSource = new EventSource(url)
   window.__mcpRelayEventSource = eventSource
@@ -253,5 +252,3 @@ if (RELAY_TOKEN && !window.__mcpRelayEventSource) {
     console.warn("[MCP Relay] SSE connection error, will retry...")
   }
 }
-
-export function useMCPRelay() {}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,12 +9,12 @@ import Todo from "./components/Todo"
 import Tooltip from "./components/Tooltip"
 import { createRoot } from "react-dom/client"
 import { useStorage } from "./context/StorageContext"
-import { useMCPRelay } from "./hooks/useMCPRelay"
+import { initMCPRelay } from "./hooks/useMCPRelay"
+
+initMCPRelay()
 
 const App = () => {
   const { fetchData } = useStorage()
-
-  useMCPRelay()
 
   React.useEffect(() => {
     fetchData()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,12 @@ import Todo from "./components/Todo"
 import Tooltip from "./components/Tooltip"
 import { createRoot } from "react-dom/client"
 import { useStorage } from "./context/StorageContext"
+import { useMCPRelay } from "./hooks/useMCPRelay"
 
 const App = () => {
   const { fetchData } = useStorage()
+
+  useMCPRelay()
 
   React.useEffect(() => {
     fetchData()

--- a/supabase/functions/mcp/handler.test.ts
+++ b/supabase/functions/mcp/handler.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { createHandler, type Data, type SupabaseClient } from "./handler"
+
+// ---- Mock DB ----------------------------------------------------------------
+
+const VALID_TOKEN = "550e8400-e29b-41d4-a716-446655440000"
+const VALID_USER_ID = "user-123"
+
+const emptyData: Data = {
+  schemaVersion: 1,
+  migrated: true,
+  filters: [],
+  tasks: {},
+  labels: [],
+  sections: {
+    completed: { collapsed: true },
+    focus: {},
+    sidebar: { collapsed: false },
+  },
+}
+
+function makeMockDb(
+  overrides: {
+    tokenValid?: boolean
+    data?: Data | null
+    setError?: string | null
+  } = {}
+): { db: SupabaseClient; writes: Data[] } {
+  const { tokenValid = true, data = emptyData, setError = null } = overrides
+  const writes: Data[] = []
+
+  const db: SupabaseClient = {
+    from: (table: string) => ({
+      select: (_cols: string) => ({
+        eq: (_col: string, val: string) => ({
+          maybeSingle: async () => {
+            if (table === "users") {
+              if (val === VALID_TOKEN && tokenValid) {
+                return { data: { id: VALID_USER_ID }, error: null }
+              }
+              return { data: null, error: null }
+            }
+            if (table === "todos") {
+              return { data: data ? { data } : null, error: null }
+            }
+            return { data: null, error: null }
+          },
+        }),
+      }),
+      upsert: async (row: unknown) => {
+        if (setError) return { error: { message: setError } }
+        writes.push((row as { data: Data }).data)
+        return { error: null }
+      },
+    }),
+  }
+
+  return { db, writes }
+}
+
+function post(body: unknown, options: {
+  token?: string | null
+  contentLength?: number
+} = {}): Request {
+  const { token = VALID_TOKEN, contentLength } = options
+  const bodyStr = JSON.stringify(body)
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Content-Length": String(contentLength ?? bodyStr.length),
+  }
+  if (token !== null) headers["Authorization"] = `Bearer ${token}`
+  return new Request("http://localhost/mcp", { method: "POST", headers, body: bodyStr })
+}
+
+// ---- Security checks --------------------------------------------------------
+
+describe("security", () => {
+  it("rejects non-POST requests", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(
+      new Request("http://localhost/mcp", { method: "GET" })
+    )
+    expect(res.status).toBe(405)
+  })
+
+  it("rejects missing Authorization header", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(post({ method: "initialize" }, { token: null }))
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects non-UUID token without touching the DB", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(
+      post({ method: "initialize" }, { token: "not-a-uuid" })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects token that is Bearer with empty value", async () => {
+    const { db } = makeMockDb()
+    const req = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: { Authorization: "Bearer ", "Content-Type": "application/json" },
+      body: JSON.stringify({ method: "initialize" }),
+    })
+    const res = await createHandler(db)(req)
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects oversized body", async () => {
+    const { db } = makeMockDb()
+    // Content-Length is a forbidden header in the Fetch API so we send a real large body
+    const largeBody = JSON.stringify({ method: "initialize", padding: "x".repeat(65 * 1024) })
+    const req = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${VALID_TOKEN}` },
+      body: largeBody,
+    })
+    const res = await createHandler(db)(req)
+    expect(res.status).toBe(413)
+  })
+
+  it("rejects valid-format token not in DB", async () => {
+    const { db } = makeMockDb({ tokenValid: false })
+    const res = await createHandler(db)(post({ method: "initialize" }))
+    expect(res.status).toBe(401)
+  })
+
+  it("does not leak internal error details to client", async () => {
+    const { db } = makeMockDb({ setError: "pg: connection reset by peer" })
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "add_todo", arguments: { title: "x" } } })
+    )
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe("Internal error")
+    expect(body.error.message).not.toContain("pg:")
+  })
+})
+
+// ---- MCP protocol -----------------------------------------------------------
+
+describe("MCP protocol", () => {
+  it("handles initialize", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "initialize" })
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.result.serverInfo.name).toBe("what-todo")
+    expect(body.result.protocolVersion).toBe("2024-11-05")
+  })
+
+  it("handles tools/list", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/list" })
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.result.tools).toHaveLength(7)
+    expect(body.result.tools.map((t: { name: string }) => t.name)).toContain("add_todo")
+  })
+
+  it("returns 404 for unknown method", async () => {
+    const { db } = makeMockDb()
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "unknown/method" })
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 400 for malformed JSON body", async () => {
+    const { db } = makeMockDb()
+    const req = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${VALID_TOKEN}`,
+        "Content-Length": "5",
+      },
+      body: "{{bad",
+    })
+    const res = await createHandler(db)(req)
+    expect(res.status).toBe(400)
+  })
+})
+
+// ---- Tools ------------------------------------------------------------------
+
+describe("tools/call", () => {
+  let db: SupabaseClient
+  let writes: Data[]
+
+  beforeEach(() => {
+    ;({ db, writes } = makeMockDb({ data: null }))
+  })
+
+  it("list_todos returns empty array when no data exists", async () => {
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "list_todos", arguments: {} } })
+    )
+    const body = await res.json()
+    expect(JSON.parse(body.result.content[0].text)).toEqual([])
+  })
+
+  it("list_todos filters completed tasks by default", async () => {
+    const data: Data = {
+      ...emptyData,
+      tasks: {
+        "Wed Jan 01 2025": [
+          { id: "t1", title: "Active", completed: false, created_at: new Date().toISOString(), labels: [] },
+          { id: "t2", title: "Done", completed: true, created_at: new Date().toISOString(), labels: [] },
+        ],
+      },
+    }
+    ;({ db, writes } = makeMockDb({ data }))
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "list_todos", arguments: {} } })
+    )
+    const body = await res.json()
+    const tasks = JSON.parse(body.result.content[0].text)
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0].title).toBe("Active")
+  })
+
+  it("list_todos includes completed when flag is set", async () => {
+    const data: Data = {
+      ...emptyData,
+      tasks: {
+        "Wed Jan 01 2025": [
+          { id: "t1", title: "Active", completed: false, created_at: new Date().toISOString(), labels: [] },
+          { id: "t2", title: "Done", completed: true, created_at: new Date().toISOString(), labels: [] },
+        ],
+      },
+    }
+    ;({ db, writes } = makeMockDb({ data }))
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "list_todos", arguments: { include_completed: true } } })
+    )
+    const body = await res.json()
+    const tasks = JSON.parse(body.result.content[0].text)
+    expect(tasks).toHaveLength(2)
+  })
+
+  it("add_todo creates a task and writes to DB", async () => {
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "add_todo", arguments: { title: "Buy milk" } } })
+    )
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(1)
+    const tasks = Object.values(writes[0].tasks).flat()
+    expect(tasks[0].title).toBe("Buy milk")
+    expect(tasks[0].completed).toBe(false)
+  })
+
+  it("add_todo preserves pinned and description", async () => {
+    await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "add_todo", arguments: { title: "Test", description: "Details", pinned: true } } })
+    )
+    const task = Object.values(writes[0].tasks).flat()[0]
+    expect(task.description).toBe("Details")
+    expect(task.pinned).toBe(true)
+  })
+
+  it("complete_todo marks task completed by title", async () => {
+    const data: Data = {
+      ...emptyData,
+      tasks: {
+        "Wed Jan 01 2025": [
+          { id: "t1", title: "Buy milk", completed: false, created_at: new Date().toISOString(), labels: [] },
+        ],
+      },
+    }
+    ;({ db, writes } = makeMockDb({ data }))
+    await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "complete_todo", arguments: { title: "milk" } } })
+    )
+    const task = Object.values(writes[0].tasks).flat()[0]
+    expect(task.completed).toBe(true)
+    expect(task.completed_at).toBeDefined()
+  })
+
+  it("complete_todo returns error when task not found", async () => {
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "complete_todo", arguments: { title: "nonexistent" } } })
+    )
+    const body = await res.json()
+    expect(body.result.isError).toBe(true)
+  })
+
+  it("pin_todo pins a task by id", async () => {
+    const data: Data = {
+      ...emptyData,
+      tasks: {
+        "Wed Jan 01 2025": [
+          { id: "t1", title: "Task", completed: false, pinned: false, created_at: new Date().toISOString(), labels: [] },
+        ],
+      },
+    }
+    ;({ db, writes } = makeMockDb({ data }))
+    await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "pin_todo", arguments: { id: "t1" } } })
+    )
+    const task = Object.values(writes[0].tasks).flat()[0]
+    expect(task.pinned).toBe(true)
+  })
+
+  it("create_label adds a label", async () => {
+    await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "create_label", arguments: { title: "Work", color: "#3b82f6" } } })
+    )
+    expect(writes[0].labels[0].title).toBe("Work")
+    expect(writes[0].labels[0].color).toBe("#3b82f6")
+  })
+
+  it("create_label is idempotent for existing title", async () => {
+    const data: Data = { ...emptyData, labels: [{ id: "l1", title: "Work", color: "#000" }] }
+    ;({ db, writes } = makeMockDb({ data }))
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "create_label", arguments: { title: "work" } } })
+    )
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(0)
+  })
+
+  it("label_todo attaches a label to a task by title", async () => {
+    const data: Data = {
+      ...emptyData,
+      tasks: {
+        "Wed Jan 01 2025": [
+          { id: "t1", title: "Buy milk", completed: false, created_at: new Date().toISOString(), labels: [] },
+        ],
+      },
+      labels: [{ id: "l1", title: "Work", color: "#000" }],
+    }
+    ;({ db, writes } = makeMockDb({ data }))
+    await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "label_todo", arguments: { task_title: "milk", label_title: "work" } } })
+    )
+    const task = Object.values(writes[0].tasks).flat()[0]
+    expect(task.labels).toContain("l1")
+  })
+
+  it("returns error for unknown tool", async () => {
+    const res = await createHandler(db)(
+      post({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "delete_everything", arguments: {} } })
+    )
+    const body = await res.json()
+    expect(body.result.isError).toBe(true)
+  })
+})

--- a/supabase/functions/mcp/handler.ts
+++ b/supabase/functions/mcp/handler.ts
@@ -1,3 +1,8 @@
+// NOTE: The tool execution logic here is intentionally self-contained.
+// Deno edge functions have strict module resolution requirements that make
+// cross-runtime imports from the Node server (server/tools.ts) fragile.
+// Keep the two in sync when adding or changing tools.
+
 // ---- Types ------------------------------------------------------------------
 
 export interface Task {

--- a/supabase/functions/mcp/handler.ts
+++ b/supabase/functions/mcp/handler.ts
@@ -1,0 +1,451 @@
+// ---- Types ------------------------------------------------------------------
+
+export interface Task {
+  id: string
+  title: string
+  description?: string
+  completed: boolean
+  pinned?: boolean
+  labels?: string[]
+  created_at: string
+  completed_at?: string
+  order?: number
+}
+
+export interface Label {
+  id: string
+  title: string
+  color: string
+}
+
+export interface Data {
+  schemaVersion?: number
+  filters: string[]
+  tasks: Record<string, Task[]>
+  labels: Label[]
+  sections?: Record<string, unknown>
+  migrated?: boolean
+}
+
+interface McpRequest {
+  method: string
+  params?: {
+    name?: string
+    arguments?: Record<string, unknown>
+  }
+  id?: string | number
+  jsonrpc?: string
+}
+
+export interface SupabaseClient {
+  from: (table: string) => {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        maybeSingle: () => Promise<{ data: unknown; error: { message: string } | null }>
+      }
+    }
+    upsert: (
+      row: unknown,
+      opts?: unknown
+    ) => Promise<{ error: { message: string } | null }>
+  }
+}
+
+// ---- Constants --------------------------------------------------------------
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const MAX_BODY_BYTES = 64 * 1024 // 64 KB
+
+const COLORS = [
+  "#ef4444", "#f97316", "#eab308", "#22c55e",
+  "#14b8a6", "#3b82f6", "#8b5cf6", "#ec4899",
+]
+
+// ---- Helpers ----------------------------------------------------------------
+
+function uuid(): string {
+  return crypto.randomUUID()
+}
+
+function todayKey(): string {
+  return new Date().toDateString()
+}
+
+function defaultData(): Data {
+  return {
+    schemaVersion: 1,
+    migrated: true,
+    filters: [],
+    tasks: {},
+    labels: [],
+    sections: {
+      completed: { collapsed: true },
+      focus: {},
+      sidebar: { collapsed: false },
+    },
+  }
+}
+
+function findTask(data: Data, id?: string, title?: string): Task | undefined {
+  const all = Object.values(data.tasks).flat()
+  if (id) return all.find((t) => t.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return all.find((t) => t.title.toLowerCase().includes(lower))
+  }
+}
+
+function findLabel(data: Data, id?: string, title?: string): Label | undefined {
+  if (id) return data.labels.find((l) => l.id === id)
+  if (title) {
+    const lower = title.toLowerCase()
+    return data.labels.find((l) => l.title.toLowerCase().includes(lower))
+  }
+}
+
+// ---- Auth -------------------------------------------------------------------
+
+async function validateToken(
+  db: SupabaseClient,
+  token: string
+): Promise<string | null> {
+  const { data, error } = await db
+    .from("users")
+    .select("id")
+    .eq("api_token", token)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return (data as { id: string }).id
+}
+
+// ---- Storage ----------------------------------------------------------------
+
+async function getData(
+  db: SupabaseClient,
+  userId: string
+): Promise<Data | null> {
+  const { data, error } = await db
+    .from("todos")
+    .select("data")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read todos: ${error.message}`)
+  return ((data as { data: Data } | null)?.data) ?? null
+}
+
+async function setData(
+  db: SupabaseClient,
+  userId: string,
+  newData: Data
+): Promise<void> {
+  const { error } = await db.from("todos").upsert(
+    { user_id: userId, data: newData, updated_at: new Date().toISOString() },
+    { onConflict: "user_id" }
+  )
+
+  if (error) throw new Error(`Failed to write todos: ${error.message}`)
+}
+
+// ---- Tool execution ---------------------------------------------------------
+
+function ok(data: unknown) {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] }
+}
+
+function toolErr(message: string) {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true }
+}
+
+async function executeTool(
+  db: SupabaseClient,
+  userId: string,
+  tool: string,
+  params: Record<string, unknown>
+) {
+  const data = (await getData(db, userId)) ?? defaultData()
+
+  switch (tool) {
+    case "list_todos": {
+      const includeCompleted = params.include_completed as boolean | undefined
+      const all = Object.values(data.tasks).flat()
+      const tasks = includeCompleted ? all : all.filter((t) => !t.completed)
+      return ok(
+        tasks.map((t) => ({
+          id: t.id, title: t.title, description: t.description,
+          completed: t.completed, pinned: t.pinned, labels: t.labels,
+          created_at: t.created_at,
+        }))
+      )
+    }
+
+    case "list_labels":
+      return ok(data.labels)
+
+    case "add_todo": {
+      const key = todayKey()
+      const task: Task = {
+        id: uuid(),
+        title: params.title as string,
+        description: (params.description as string) || undefined,
+        labels: (params.labels as string[]) || [],
+        pinned: (params.pinned as boolean) || false,
+        completed: false,
+        created_at: new Date().toISOString(),
+      }
+      data.tasks[key] = [task, ...(data.tasks[key] || [])]
+      await setData(db, userId, data)
+      return ok({ message: `Added todo: ${task.title}` })
+    }
+
+    case "complete_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return toolErr("Task not found")
+      task.completed = true
+      task.completed_at = new Date().toISOString()
+      await setData(db, userId, data)
+      return ok({ message: `Completed: ${task.title}` })
+    }
+
+    case "pin_todo": {
+      const task = findTask(data, params.id as string, params.title as string)
+      if (!task) return toolErr("Task not found")
+      task.pinned = (params.pinned as boolean) ?? true
+      await setData(db, userId, data)
+      return ok({ message: `${task.pinned ? "Pinned" : "Unpinned"}: ${task.title}` })
+    }
+
+    case "create_label": {
+      const existing = data.labels.find(
+        (l) => l.title.toLowerCase() === (params.title as string).toLowerCase()
+      )
+      if (existing) return ok({ message: `Label already exists: ${existing.title}` })
+      const label: Label = {
+        id: uuid(),
+        title: params.title as string,
+        color:
+          (params.color as string) ||
+          COLORS[Math.floor(Math.random() * COLORS.length)],
+      }
+      data.labels.push(label)
+      await setData(db, userId, data)
+      return ok({ message: `Created label: ${label.title}` })
+    }
+
+    case "label_todo": {
+      const task = findTask(
+        data,
+        params.task_id as string,
+        params.task_title as string
+      )
+      if (!task) return toolErr("Task not found")
+      const label = findLabel(
+        data,
+        params.label_id as string,
+        params.label_title as string
+      )
+      if (!label) return toolErr("Label not found")
+      task.labels = [...new Set([...(task.labels || []), label.id])]
+      await setData(db, userId, data)
+      return ok({ message: `Added label "${label.title}" to "${task.title}"` })
+    }
+
+    default:
+      return toolErr(`Unknown tool: ${tool}`)
+  }
+}
+
+// ---- MCP protocol -----------------------------------------------------------
+
+const TOOLS = [
+  {
+    name: "list_todos",
+    description: "List current todos. Returns all uncompleted tasks by default.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        include_completed: { type: "boolean", description: "Include completed tasks. Defaults to false." },
+      },
+    },
+  },
+  {
+    name: "list_labels",
+    description: "List all available labels with their id, title, and color.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "add_todo",
+    description: "Add a new todo task to today's list.",
+    inputSchema: {
+      type: "object",
+      required: ["title"],
+      properties: {
+        title: { type: "string", description: "The task title" },
+        description: { type: "string", description: "Optional task description" },
+        labels: { type: "array", items: { type: "string" } },
+        pinned: { type: "boolean", description: "Whether to pin the task." },
+      },
+    },
+  },
+  {
+    name: "complete_todo",
+    description: "Mark a todo as completed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        title: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "pin_todo",
+    description: "Pin or unpin a todo.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        title: { type: "string" },
+        pinned: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "create_label",
+    description: "Create a new label for categorizing todos.",
+    inputSchema: {
+      type: "object",
+      required: ["title"],
+      properties: {
+        title: { type: "string" },
+        color: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "label_todo",
+    description: "Add a label to a todo.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string" },
+        task_title: { type: "string" },
+        label_id: { type: "string" },
+        label_title: { type: "string" },
+      },
+    },
+  },
+]
+
+function mcpResponse(id: string | number | undefined, result: unknown) {
+  return { jsonrpc: "2.0", id: id ?? null, result }
+}
+
+function mcpError(id: string | number | undefined, code: number, message: string) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } }
+}
+
+// ---- Main handler (exported for testing) -----------------------------------
+
+export function createHandler(db: SupabaseClient) {
+  return async (req: Request): Promise<Response> => {
+    // 1. POST only
+    if (req.method !== "POST") {
+      return new Response("Method Not Allowed", { status: 405 })
+    }
+
+    // 2. Body size limit — check header first (cheap), then actual body
+    const contentLength = Number(req.headers.get("content-length") ?? 0)
+    if (contentLength > MAX_BODY_BYTES) {
+      return new Response("Payload Too Large", { status: 413 })
+    }
+
+    // 3. Auth header must be present — no DB query
+    const authHeader = req.headers.get("authorization")
+    if (!authHeader?.startsWith("Bearer ")) {
+      return new Response("Unauthorized", { status: 401 })
+    }
+
+    const token = authHeader.slice(7).trim()
+    if (!token) {
+      return new Response("Unauthorized", { status: 401 })
+    }
+
+    // 4. UUID format check — reject garbage tokens without touching the DB
+    if (!UUID_RE.test(token)) {
+      return new Response("Unauthorized", { status: 401 })
+    }
+
+    // TODO: add Upstash rate limiting here (per-IP, before validateToken)
+
+    // 5. Validate token against DB
+    const userId = await validateToken(db, token)
+    if (!userId) {
+      return new Response(
+        JSON.stringify(mcpError(null, -32600, "Invalid API token")),
+        { status: 401, headers: { "Content-Type": "application/json" } }
+      )
+    }
+
+    // 6. Parse body — also enforce size limit on actual bytes
+    let body: McpRequest
+    try {
+      const raw = await req.text()
+      if (raw.length > MAX_BODY_BYTES) {
+        return new Response("Payload Too Large", { status: 413 })
+      }
+      body = JSON.parse(raw)
+    } catch {
+      return new Response(
+        JSON.stringify(mcpError(null, -32700, "Parse error")),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      )
+    }
+
+    const { method, params, id } = body
+
+    if (method === "initialize") {
+      return Response.json(
+        mcpResponse(id, {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "what-todo", version: "1.0.0" },
+        })
+      )
+    }
+
+    if (method === "tools/list") {
+      return Response.json(mcpResponse(id, { tools: TOOLS }))
+    }
+
+    if (method === "tools/call") {
+      const toolName = params?.name
+      const toolArgs = (params?.arguments ?? {}) as Record<string, unknown>
+
+      if (!toolName) {
+        return Response.json(mcpError(id, -32602, "Missing tool name"), {
+          status: 400,
+        })
+      }
+
+      try {
+        const result = await executeTool(db, userId, toolName, toolArgs)
+        return Response.json(mcpResponse(id, result))
+      } catch (e) {
+        // Log detail server-side, return generic message to client
+        console.error("[MCP] tool error:", e)
+        return Response.json(mcpError(id, -32603, "Internal error"), {
+          status: 500,
+        })
+      }
+    }
+
+    return Response.json(
+      mcpError(id, -32601, `Method not found: ${method}`),
+      { status: 404 }
+    )
+  }
+}

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -1,0 +1,14 @@
+import { createClient } from "npm:@supabase/supabase-js@2"
+import { createHandler } from "./handler.ts"
+
+// TODO: add Upstash rate limiting once traffic warrants it
+// import { Ratelimit } from "npm:@upstash/ratelimit@2"
+// import { Redis } from "npm:@upstash/redis@1"
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  { auth: { persistSession: false } }
+)
+
+Deno.serve(createHandler(supabase))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,14 @@ export default defineConfig({
       }
     })
   ],
+  server: {
+    proxy: {
+      "/relay": {
+        target: "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: "happy-dom",
     globals: true,


### PR DESCRIPTION
Adds an MCP server that exposes the What Todo app as a set of tools usable by Claude Code and other MCP clients. Since the app's data lives in browser localStorage, a simple relay bridges the gap: the Node MCP server pushes commands to a connected browser tab over SSE, executes them in-context, and streams the results back. The Vite dev server proxies `/relay/*` to the local relay process, and `StorageContext` exposes a notify hook so the UI re-renders after relay writes.

To test, run the dev server alongside the relay (`pnpm dev`), open the app in a browser, then configure the MCP server in Claude Code and try calling `list_todos`, `add_todo`, etc.