### PR TITLE
Add worktree and git workflow instructions to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ dist
 test-results/
 playwright-report/
 .claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # What Todo
 
+## Working with Git
+
+- Use **worktrees** for all non-trivial changes — create one with the `EnterWorktree` tool at the start of a task
+- Use `git` and `gh` for version control — do not use Graphite
+- To create a PR, use the `/create-pr` command
+
+
+
 A personal todo app built as a PWA with offline support.
 
 ## Tech Stack


### PR DESCRIPTION
Future agents working in this repo had no guidance on how to manage branches or open PRs. This adds a short "Working with Git" section to CLAUDE.md instructing agents to use worktrees for non-trivial changes, use `git`/`gh` (not Graphite), and use the `/create-pr` command.

Check that the section appears at the top of CLAUDE.md and that a new agent session picks up the instructions.