### PR TITLE
Add loading skeleton for backend storage fetching

### DIFF
--- a/src/adapters/DebouncedAdapter.ts
+++ b/src/adapters/DebouncedAdapter.ts
@@ -19,6 +19,8 @@ export interface SyncListener {
 }
 
 export class DebouncedAdapter implements StorageAdapter {
+  readonly isAsync = true
+
   private timer: ReturnType<typeof setTimeout> | null = null
   private pendingData: Data | null = null
   private writePromise: Promise<void> | null = null

--- a/src/adapters/StorageAdapter.ts
+++ b/src/adapters/StorageAdapter.ts
@@ -18,6 +18,13 @@ export interface StorageAdapter {
   clear(): Promise<void>
 
   /**
+   * Whether this adapter requires async network access.
+   * When true, the UI should show a loading indicator during initial fetch.
+   * Synchronous adapters (e.g. localStorage) return false or omit this.
+   */
+  readonly isAsync?: boolean
+
+  /**
    * Verify the adapter can connect to its backend.
    * Throws with a descriptive message if the connection fails.
    * Adapters that don't need connection testing (e.g. localStorage)

--- a/src/components/LoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeleton.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import LoadingSkeleton from "./LoadingSkeleton"
+
+describe("LoadingSkeleton", () => {
+  it("renders with accessible status role and label", () => {
+    render(<LoadingSkeleton />)
+    const skeleton = screen.getByRole("status")
+    expect(skeleton).toBeTruthy()
+    expect(skeleton.getAttribute("aria-label")).toBe("Loading tasks")
+  })
+
+  it("has the correct test id", () => {
+    render(<LoadingSkeleton />)
+    expect(screen.getByTestId("loading-skeleton")).toBeTruthy()
+  })
+
+  it("renders skeleton task rows and a search bar placeholder", () => {
+    render(<LoadingSkeleton />)
+    const skeleton = screen.getByTestId("loading-skeleton")
+    // Search bar + task rows should produce child content
+    const rows =
+      skeleton.querySelector(".divide-y")?.children ?? ([] as unknown)
+    expect((rows as HTMLCollection).length).toBe(5)
+  })
+
+  it("includes screen reader text", () => {
+    render(<LoadingSkeleton />)
+    expect(screen.getByText("Loading tasks…")).toBeTruthy()
+  })
+})

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,95 @@
+import type { CSSProperties } from "react"
+
+function SkeletonPulse({
+  className = "",
+  style
+}: {
+  className?: string
+  style?: CSSProperties
+}) {
+  return (
+    <div
+      className={`rounded-md bg-slate-200 dark:bg-navy-700 animate-pulse ${className}`}
+      style={style}
+    />
+  )
+}
+
+function SkeletonTask({ index }: { index: number }) {
+  // Vary widths to look natural
+  const titleWidths = ["60%", "75%", "45%", "80%", "55%"]
+  const hasDescription = index % 3 === 0
+  const hasLabel = index % 2 === 0
+  const delay = `${index * 75}ms`
+
+  return (
+    <div className="flex items-start gap-3 py-3">
+      {/* Checkbox skeleton */}
+      <SkeletonPulse
+        className="shrink-0 mt-0.5"
+        style={{
+          width: 18,
+          height: 18,
+          borderRadius: 4,
+          animationDelay: delay
+        }}
+      />
+
+      {/* Content skeleton */}
+      <div className="flex-1 flex flex-col gap-1.5">
+        {/* Title */}
+        <SkeletonPulse
+          style={{
+            width: titleWidths[index % titleWidths.length],
+            height: 16,
+            animationDelay: delay
+          }}
+        />
+
+        {/* Description (some tasks) */}
+        {hasDescription && (
+          <SkeletonPulse
+            style={{ width: "40%", height: 12, animationDelay: delay }}
+          />
+        )}
+
+        {/* Label (some tasks) */}
+        {hasLabel && (
+          <SkeletonPulse
+            className="mt-0.5"
+            style={{
+              width: 56,
+              height: 20,
+              borderRadius: 9999,
+              animationDelay: delay
+            }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function LoadingSkeleton() {
+  return (
+    <div
+      className="px-6 pt-6"
+      role="status"
+      aria-label="Loading tasks"
+      data-testid="loading-skeleton"
+    >
+      {/* Search bar skeleton */}
+      <SkeletonPulse className="mb-4" style={{ width: "100%", height: 40 }} />
+
+      {/* Task skeletons */}
+      <div className="divide-y divide-slate-100 dark:divide-navy-800">
+        {Array.from({ length: 5 }, (_, i) => (
+          <SkeletonTask key={i} index={i} />
+        ))}
+      </div>
+
+      {/* Screen reader text */}
+      <span className="sr-only">Loading tasks…</span>
+    </div>
+  )
+}

--- a/src/components/Todo.spec.tsx
+++ b/src/components/Todo.spec.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
 import Todo from "./Todo"
 import { SettingsProvider } from "../context/SettingsContext"
 import { DarkModeProvider } from "../context/DarkModeContext"
@@ -9,6 +9,7 @@ const yesterday = new Date(Date.now() - 86400000).toDateString()
 const mockMoveToToday = vi.fn()
 
 let testData: Record<string, any> = {}
+let testLoading = false
 
 function makeDefaultData(overrides: Record<string, any> = {}) {
   return {
@@ -30,6 +31,7 @@ function makeDefaultData(overrides: Record<string, any> = {}) {
 vi.mock("../context/StorageContext", () => ({
   useStorage: () => ({
     data: testData,
+    loading: testLoading,
     labelsById: {
       l1: { id: "l1", title: "Work", color: "#5352ed" },
       l2: { id: "l2", title: "Personal", color: "#ff7f50" }
@@ -72,6 +74,31 @@ function renderTodo() {
     </DarkModeProvider>
   )
 }
+
+describe("Todo — loading state", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockMoveToToday.mockClear()
+    testData = makeDefaultData()
+  })
+
+  afterEach(() => {
+    testLoading = false
+  })
+
+  it("shows loading skeleton and hides task list when loading is true", () => {
+    testLoading = true
+    renderTodo()
+    expect(screen.queryByTestId("loading-skeleton")).toBeTruthy()
+    expect(screen.queryByPlaceholderText("Search tasks...")).toBeNull()
+  })
+
+  it("does not show loading skeleton when loading is false", () => {
+    testLoading = false
+    renderTodo()
+    expect(screen.queryByTestId("loading-skeleton")).toBeNull()
+  })
+})
 
 describe("Todo — curtain sidebar animation", () => {
   beforeEach(() => {

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -32,6 +32,7 @@ import ChevronUp from "@meronex/icons/fi/FiChevronUp"
 import SearchIcon from "@meronex/icons/fi/FiSearch"
 import CheckIcon from "@meronex/icons/fi/FiCheckCircle"
 import Toast from "./Toast"
+import LoadingSkeleton from "./LoadingSkeleton"
 import useKeyboardAware from "../hooks/useKeyboardAware"
 
 function Title({ children }: PropsWithChildren) {
@@ -69,6 +70,7 @@ const Todo: React.FC = ({}) => {
   useKeyboardAware()
   const {
     data,
+    loading,
     sections,
     labelsById,
     addTask,
@@ -536,57 +538,63 @@ const Todo: React.FC = ({}) => {
               className="flex-1 overflow-y-auto min-h-0 px-6"
               aria-label="Task list"
             >
-              {data.filters.length > 0 && (
-                <div className="mt-2 mb-4">
-                  <small>Showing: </small>
-                  {data.filters.map(id => (
-                    <div className="inline mb-1 mr-1" key={id}>
-                      <Label
-                        active
-                        label={labelsById[id]}
-                        onRemove={() => {
-                          updateFilters(data.filters.filter(x => x !== id))
-                        }}
-                      />
+              {loading ? (
+                <LoadingSkeleton />
+              ) : (
+                <>
+                  {data.filters.length > 0 && (
+                    <div className="mt-2 mb-4">
+                      <small>Showing: </small>
+                      {data.filters.map(id => (
+                        <div className="inline mb-1 mr-1" key={id}>
+                          <Label
+                            active
+                            label={labelsById[id]}
+                            onRemove={() => {
+                              updateFilters(data.filters.filter(x => x !== id))
+                            }}
+                          />
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              )}
+                  )}
 
-              {todaysTasks.length > 0 && (
-                <search className="mb-3 sticky top-0 z-10 pt-3">
-                  <div className="relative">
-                    <SearchIcon
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 dark:text-navy-400 z-10"
-                      fontSize={14}
-                    />
-                    <input
-                      type="text"
-                      value={searchQuery}
-                      onChange={e => setSearchQuery(e.target.value)}
-                      onKeyDown={e => {
-                        if (e.key === "Escape") setSearchQuery("")
-                      }}
-                      placeholder="Search tasks..."
-                      className="w-full text-sm bg-slate-100/70 dark:bg-navy-800/70 backdrop-blur-md rounded-lg pl-8 pr-3 py-2.5 outline-none placeholder-slate-400 dark:placeholder-navy-400 dark:text-navy-100 border border-slate-200/50 dark:border-navy-700/50"
-                    />
-                  </div>
-                </search>
-              )}
+                  {todaysTasks.length > 0 && (
+                    <search className="mb-3 sticky top-0 z-10 pt-3">
+                      <div className="relative">
+                        <SearchIcon
+                          className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 dark:text-navy-400 z-10"
+                          fontSize={14}
+                        />
+                        <input
+                          type="text"
+                          value={searchQuery}
+                          onChange={e => setSearchQuery(e.target.value)}
+                          onKeyDown={e => {
+                            if (e.key === "Escape") setSearchQuery("")
+                          }}
+                          placeholder="Search tasks..."
+                          className="w-full text-sm bg-slate-100/70 dark:bg-navy-800/70 backdrop-blur-md rounded-lg pl-8 pr-3 py-2.5 outline-none placeholder-slate-400 dark:placeholder-navy-400 dark:text-navy-100 border border-slate-200/50 dark:border-navy-700/50"
+                        />
+                      </div>
+                    </search>
+                  )}
 
-              <List
-                tasks={visibleTasks}
-                labels={labelsById}
-                filters={data.filters}
-                isFiltering={isFiltering}
-                onFilter={updateFilters}
-                onUpdateTask={handleUpdateTask}
-                onRemoveTask={handleRemoveTask}
-                onMarkAsComplete={markAsComplete}
-                onReorder={reordered => {
-                  reordered.forEach(t => handleUpdateTask(t))
-                }}
-              />
+                  <List
+                    tasks={visibleTasks}
+                    labels={labelsById}
+                    filters={data.filters}
+                    isFiltering={isFiltering}
+                    onFilter={updateFilters}
+                    onUpdateTask={handleUpdateTask}
+                    onRemoveTask={handleRemoveTask}
+                    onMarkAsComplete={markAsComplete}
+                    onReorder={reordered => {
+                      reordered.forEach(t => handleUpdateTask(t))
+                    }}
+                  />
+                </>
+              )}
             </section>
 
             <div className="pt-3 pb-4 px-6 bg-white dark:bg-navy-900">

--- a/src/context/StorageContext.tsx
+++ b/src/context/StorageContext.tsx
@@ -32,6 +32,7 @@ function createInitialAdapter(): StorageAdapter {
 
 interface Storage {
   data: Data
+  loading: boolean
   labelsById: Record<string, Label>
   storage: StorageManager
   sections?: Record<Section, SectionData>
@@ -63,6 +64,7 @@ const defaultStorage = new StorageManager(new LocalStorageAdapter())
 
 export const StorageContext = React.createContext<Storage>({
   data: defaultStorage.defaultData,
+  loading: false,
   labelsById: {},
   sections: defaultStorage.defaultData.sections,
   storage: defaultStorage,
@@ -103,6 +105,9 @@ function StorageProvider({
   const storage = storageRef.current
 
   const [data, setDataFn] = React.useState<Data>(storage.defaultData)
+  const [loading, setLoading] = useState(
+    () => initialAdapterRef.current?.isAsync === true
+  )
   const [isSupabaseConnected, setIsSupabaseConnected] = useState(
     () => getSupabaseConfig() !== null
   )
@@ -133,9 +138,17 @@ function StorageProvider({
   }
 
   const fetchData = useCallback(() => {
-    storage.getData().then(({ data }) => {
-      setData(data)
-    })
+    storage
+      .getData()
+      .then(({ data }) => {
+        setData(data)
+      })
+      .catch(err => {
+        console.error("[StorageProvider] fetchData failed:", err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
   }, [storage])
 
   const dataRef = React.useRef(data)
@@ -148,14 +161,15 @@ function StorageProvider({
     if (getSupabaseConfig()) return
 
     if (isAuthenticated) {
+      setLoading(true)
       const appAdapter = new AppSupabaseAdapter()
       const newAdapter = new DebouncedAdapter(appAdapter)
       attachSyncListener(newAdapter)
 
       const localAdapter = new LocalStorageAdapter()
 
-      Promise.all([localAdapter.get(), appAdapter.get()]).then(
-        ([local, remote]) => {
+      Promise.all([localAdapter.get(), appAdapter.get()])
+        .then(([local, remote]) => {
           const hasLocal =
             local && Object.values(local.tasks ?? {}).flat().length > 0
           const hasRemote =
@@ -177,8 +191,11 @@ function StorageProvider({
             storage.setAdapter(newAdapter)
             fetchData()
           }
-        }
-      )
+        })
+        .catch(err => {
+          console.error("[StorageProvider] auth adapter switch failed:", err)
+          setLoading(false)
+        })
     } else {
       storage.setAdapter(new LocalStorageAdapter())
       setSyncStatus("idle")
@@ -207,6 +224,8 @@ function StorageProvider({
     if (rawAdapter.testConnection) {
       await rawAdapter.testConnection()
     }
+
+    setLoading(true)
 
     const currentAdapter = new LocalStorageAdapter()
     await migrateData(currentAdapter, rawAdapter)
@@ -274,6 +293,7 @@ function StorageProvider({
     addLabel,
     addTask: addTask.bind(storage),
     data,
+    loading,
     fetchData,
     labelsById,
     markAsComplete: updateTask,


### PR DESCRIPTION
When fetching data from a backend adapter (Supabase), the app previously showed an empty task list during the network request. Now it displays a skeleton loading animation that mimics the task list layout — a pulsing search bar and five task placeholders with staggered animation delays for a natural look. The loading state is intentionally skipped for localStorage since reads are synchronous and instantaneous.

The `loading` boolean lives in `StorageContext` and is set to `true` when the active adapter has `isAsync: true` (a new property on the `StorageAdapter` interface — currently only `DebouncedAdapter` sets it). Loading resets to `false` via `.finally()` on `fetchData`, so the skeleton is always cleared even on errors. The `connectSupabase` flow also shows the skeleton during migration + fetch.

To verify, connect a Supabase backend and refresh — you should see the skeleton briefly before tasks appear.
