### PR TITLE
Fix 70 failing unit tests with localStorage polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ dist
 test-results/
 playwright-report/
 .claude/settings.local.json
-.claude/worktrees/
+**/worktrees/

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Vitest setup file.
+ *
+ * happy-dom exposes localStorage on its Window object, but vitest
+ * does not always copy it to the global scope. This shim ensures a
+ * working localStorage is available in every test.
+ */
+
+if (typeof globalThis.localStorage === "undefined" || typeof globalThis.localStorage.clear !== "function") {
+  const store = new Map<string, string>()
+
+  globalThis.localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, String(value)),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size
+    },
+    key: (index: number) => [...store.keys()][index] ?? null
+  } as Storage
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,7 +6,10 @@
  * working localStorage is available in every test.
  */
 
-if (typeof globalThis.localStorage === "undefined" || typeof globalThis.localStorage.clear !== "function") {
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  typeof globalThis.localStorage.clear !== "function"
+) {
   const store = new Map<string, string>()
 
   globalThis.localStorage = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
+    setupFiles: ["./src/test-setup.ts"],
     exclude: ["e2e/**", "node_modules/**"]
   }
 })


### PR DESCRIPTION
## Summary
- Added `src/test-setup.ts` that polyfills `localStorage` when happy-dom fails to expose it to the global scope
- Registered the setup file in `vite.config.ts` via `setupFiles`
- All 230 tests now pass (previously 70 were failing since PR #103)

## Root cause
`happy-dom` does not reliably initialize `localStorage` in vitest's global scope, causing any test calling `localStorage.clear()` or `localStorage.setItem()` to throw. Bisected to commit `e3dc37f` ("Improve unit test coverage (#103)") which added tests that relied on `localStorage` directly.

## Test plan
- [x] `pnpm test` — 230/230 passing
- [x] `pnpm typecheck` — clean