### PR TITLE
Remove sticky positioning from search bar and reorder button

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -566,7 +566,7 @@ const Todo: React.FC = ({}) => {
                   )}
 
                   {todaysTasks.length > 0 && (
-                    <search className="mb-3 sticky top-0 z-10 pt-3">
+                    <search className="mb-3">
                       <div className="flex items-center gap-2">
                         <div className="relative flex-1">
                           <SearchIcon


### PR DESCRIPTION
The search bar and reorder button were pinned to the top of the scroll container with `sticky top-0 z-10`, causing them to float over content while scrolling. Removing the sticky classes lets them flow naturally with the rest of the list.

Scroll through a list with several tasks to confirm the search bar and reorder button scroll away with the content instead of staying fixed at the top.