### PR TITLE
Reduce label filter spacing and always show icons on mobile

### DIFF
--- a/src/components/McpSetupSheet.tsx
+++ b/src/components/McpSetupSheet.tsx
@@ -34,7 +34,7 @@ function CodeBlock({ code }: { code: string }) {
       <pre className="bg-slate-900 dark:bg-navy-950 text-slate-100 text-[12px] rounded-lg p-4 overflow-x-auto leading-relaxed">
         {code}
       </pre>
-      <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="absolute top-2 right-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
         <CopyButton value={code} />
       </div>
     </div>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -549,7 +549,7 @@ const Todo: React.FC = ({}) => {
               ) : (
                 <>
                   {data.filters.length > 0 && (
-                    <div className="mt-2 mb-4">
+                    <div className="mt-2 mb-2">
                       <small>Showing: </small>
                       {data.filters.map(id => (
                         <div className="inline mb-1 mr-1" key={id}>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -219,11 +219,13 @@
 
   /* On touch devices, all icons (including pin) are always visible */
   @media (hover: none) {
+    .label-input .remove-icon,
     .task .remove-icon {
       visibility: visible;
       color: #777;
     }
 
+    html.dark .label-input .remove-icon,
     html.dark .task .remove-icon {
       color: #b1b6c5;
     }


### PR DESCRIPTION
The gap between the "Showing: <labels>" filter row and the search bar was too large (`mb-4`), reduced to `mb-2` to tighten the layout. Additionally, hover-revealed icons (task actions, label remove buttons, code block copy button) were invisible on touch devices where hover never fires — these are now always visible on mobile using `@media (hover: none)` and responsive opacity classes.

Filter by a label on mobile to check the spacing, then verify task action icons and the copy button in the MCP setup sheet are visible without tapping first.