### PR TITLE
Restore top padding on search bar

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -566,7 +566,7 @@ const Todo: React.FC = ({}) => {
                   )}
 
                   {todaysTasks.length > 0 && (
-                    <search className="mb-3 pt-3">
+                    <search className="mb-3 pt-2">
                       <div className="flex items-center gap-2">
                         <div className="relative flex-1">
                           <SearchIcon

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -566,7 +566,7 @@ const Todo: React.FC = ({}) => {
                   )}
 
                   {todaysTasks.length > 0 && (
-                    <search className="mb-3">
+                    <search className="mb-3 pt-3">
                       <div className="flex items-center gap-2">
                         <div className="relative flex-1">
                           <SearchIcon

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -566,7 +566,7 @@ const Todo: React.FC = ({}) => {
                   )}
 
                   {todaysTasks.length > 0 && (
-                    <search className="mb-3 pt-2">
+                    <search className="mb-3 pt-3">
                       <div className="flex items-center gap-2">
                         <div className="relative flex-1">
                           <SearchIcon


### PR DESCRIPTION
Removing the sticky positioning from the search bar also dropped the `pt-3` that was providing space between it and the header. Adding it back independently restores the gap without re-introducing stickiness.