### PR TITLE
Fix avatar loading, increase header icon sizes, enlarge mobile toggles, and fix lint warnings

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type SyntheticEvent } from "react"
+import { useCallback, useRef, useState } from "react"
 import cx from "classnames"
 import MenuIcon from "@meronex/icons/fi/FiMenu"
 import SupabaseConnector from "./SupabaseConnector"
@@ -79,10 +79,7 @@ function UserMenu({
             width={34}
             height={34}
             className="w-[34px] h-[34px] rounded-full"
-            onError={(e: SyntheticEvent<HTMLImageElement>) => {
-              e.currentTarget.style.display = "none"
-              setAvatarError(true)
-            }}
+            onError={() => setAvatarError(true)}
           />
         ) : (
           <span className="w-[34px] h-[34px] rounded-full bg-slate-200 dark:bg-navy-600 flex items-center justify-center text-sm font-semibold text-slate-600 dark:text-navy-300">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useRef, useState, type SyntheticEvent } from "react"
 import cx from "classnames"
 import MenuIcon from "@meronex/icons/fi/FiMenu"
 import SupabaseConnector from "./SupabaseConnector"
@@ -56,6 +56,7 @@ function UserMenu({
   onOpenStorage: () => void
 }) {
   const [open, setOpen] = useState(false)
+  const [avatarError, setAvatarError] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
   useOnClickOutside(ref, () => setOpen(false))
@@ -71,17 +72,20 @@ function UserMenu({
         onClick={() => setOpen(prev => !prev)}
         aria-label="Account menu"
       >
-        {avatar ? (
+        {avatar && !avatarError ? (
           <img
             src={avatar}
             alt={email ?? "User"}
-            width={28}
-            height={28}
-            loading="lazy"
-            className="w-7 h-7 rounded-full"
+            width={34}
+            height={34}
+            className="w-[34px] h-[34px] rounded-full"
+            onError={(e: SyntheticEvent<HTMLImageElement>) => {
+              e.currentTarget.style.display = "none"
+              setAvatarError(true)
+            }}
           />
         ) : (
-          <span className="w-7 h-7 rounded-full bg-slate-200 dark:bg-navy-600 flex items-center justify-center text-xs font-semibold text-slate-600 dark:text-navy-300">
+          <span className="w-[34px] h-[34px] rounded-full bg-slate-200 dark:bg-navy-600 flex items-center justify-center text-sm font-semibold text-slate-600 dark:text-navy-300">
             {(email ?? "?")[0].toUpperCase()}
           </span>
         )}
@@ -278,7 +282,7 @@ function Header({
             onClick={onMenuClick}
             aria-label="Open menu"
           >
-            <MenuIcon fontSize={22} />
+            <MenuIcon fontSize={28} />
           </button>
         )}
       </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -21,13 +21,15 @@ function Toggle({
       aria-checked={checked}
       aria-label={label}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200 ${
+      className={`relative inline-flex h-8 w-14 md:h-5 md:w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200 ${
         checked ? "bg-blue-500" : "bg-slate-300 dark:bg-navy-600"
       }`}
     >
       <span
-        className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-xs transform transition-transform duration-200 mt-0.5 ${
-          checked ? "translate-x-[18px]" : "translate-x-0.5"
+        className={`pointer-events-none inline-block h-[26px] w-[26px] md:h-4 md:w-4 rounded-full bg-white shadow-xs transform transition-transform duration-200 mt-[3px] md:mt-0.5 ${
+          checked
+            ? "translate-x-[26px] md:translate-x-[18px]"
+            : "translate-x-0.5"
         }`}
       />
     </button>

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -101,26 +101,28 @@ const Task: React.FC<Props> = ({
   const { settings } = useSettings()
   const ref = useRef<HTMLDivElement>(null)
   const [localState, setLocalState] = React.useState<TaskType | undefined>(task)
-  const prevTaskRef = React.useRef<TaskType>(task)
 
-  // Derived state during render: when the task prop changes externally, sync
-  // only the fields that differ — preserving any in-progress local edits.
-  // Calling setState here (not in an effect) is intentional per React docs:
-  // React re-renders immediately and the stale render output is discarded.
-  if (prevTaskRef.current !== task) {
+  // When the task prop changes externally, sync only the fields that differ
+  // — preserving any in-progress local edits.
+  const prevTaskRef = React.useRef<TaskType>(task)
+  React.useEffect(() => {
     const prev = prevTaskRef.current
-    prevTaskRef.current = task
-    if (localState) {
-      const patch: Partial<TaskType> = {}
-      if (prev.pinned !== task.pinned) patch.pinned = task.pinned
-      if (prev.completed !== task.completed) patch.completed = task.completed
-      if (prev.labels?.join(",") !== task.labels?.join(","))
-        patch.labels = task.labels
-      if (Object.keys(patch).length > 0) {
-        setLocalState({ ...localState, ...patch })
-      }
+    if (prev !== task) {
+      prevTaskRef.current = task
+      setLocalState(current => {
+        if (!current) return current
+        const patch: Partial<TaskType> = {}
+        if (prev.pinned !== task.pinned) patch.pinned = task.pinned
+        if (prev.completed !== task.completed) patch.completed = task.completed
+        if (prev.labels?.join(",") !== task.labels?.join(","))
+          patch.labels = task.labels
+        if (Object.keys(patch).length > 0) {
+          return { ...current, ...patch }
+        }
+        return current
+      })
     }
-  }
+  }, [task])
 
   const state = localState
   const setState = (t: TaskType | undefined) => setLocalState(t)


### PR DESCRIPTION
- Avatar: remove lazy loading, add onError fallback to show initials when image fails
- Avatar: increase size from 28px to 34px for better mobile tap targets
- Burger menu icon: increase from 22px to 28px
- Settings toggles: increase from 20x36px to 32x56px on mobile (unchanged on desktop)
- Task.tsx: move ref access from render to useEffect to fix react-hooks/refs warnings
