### PR TITLE
Add mobile label filter dropdown above task input

### DIFF
--- a/src/components/MobileLabelFilter.tsx
+++ b/src/components/MobileLabelFilter.tsx
@@ -1,0 +1,98 @@
+import React, { useRef, useState } from "react"
+import { Label as LabelType } from "../index.d"
+import ChevronDown from "@meronex/icons/fi/FiChevronDown"
+import FilterIcon from "@meronex/icons/fi/FiFilter"
+import CheckIcon from "@meronex/icons/fi/FiCheck"
+import useOnClickOutside from "../hooks/onclickoutside"
+
+interface Props {
+  labels: LabelType[]
+  filters: string[]
+  onFilter: (filters: string[]) => void
+}
+
+const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(ref, () => setOpen(false))
+
+  if (labels.length === 0) return null
+
+  const activeCount = filters.length
+
+  const toggleLabel = (id: string) => {
+    if (filters.includes(id)) {
+      onFilter(filters.filter(f => f !== id))
+    } else {
+      onFilter([...filters, id])
+    }
+  }
+
+  const clearAll = () => {
+    onFilter([])
+    setOpen(false)
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
+      >
+        <FilterIcon fontSize={12} />
+        <span>{activeCount > 0 ? `Filtering (${activeCount})` : "Filter"}</span>
+        <ChevronDown
+          fontSize={12}
+          className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute bottom-full left-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">
+          <div className="px-3 pt-2.5 pb-1.5 flex items-center justify-between">
+            <span className="text-xs font-medium text-slate-400 dark:text-navy-400 uppercase tracking-wide">
+              Filter by label
+            </span>
+            {activeCount > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="no-style text-xs text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          <div className="px-1.5 pb-1.5">
+            {labels.map(label => {
+              const isActive = filters.includes(label.id)
+              return (
+                <button
+                  key={label.id}
+                  type="button"
+                  onClick={() => toggleLabel(label.id)}
+                  className="no-style flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-sm text-slate-700 dark:text-navy-200 hover:bg-slate-50 dark:hover:bg-navy-700/50 transition-colors"
+                >
+                  <span
+                    className="w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: label.color }}
+                  />
+                  <span className="flex-1 text-left truncate">
+                    {label.title}
+                  </span>
+                  {isActive && (
+                    <CheckIcon fontSize={14} style={{ color: label.color }} />
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MobileLabelFilter

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -31,6 +31,7 @@ import ChevronDown from "@meronex/icons/fi/FiChevronDown"
 import ChevronUp from "@meronex/icons/fi/FiChevronUp"
 import SearchIcon from "@meronex/icons/fi/FiSearch"
 import EditIcon from "@meronex/icons/fi/FiEdit2"
+import MobileLabelFilter from "./MobileLabelFilter"
 import CheckIcon from "@meronex/icons/fi/FiCheckCircle"
 import Toast from "./Toast"
 import LoadingSkeleton from "./LoadingSkeleton"
@@ -548,7 +549,7 @@ const Todo: React.FC = ({}) => {
                 <LoadingSkeleton />
               ) : (
                 <>
-                  {data.filters.length > 0 && (
+                  {data.filters.length > 0 && isDesktop && (
                     <div className="mt-2 mb-2">
                       <small>Showing: </small>
                       {data.filters.map(id => (
@@ -620,6 +621,15 @@ const Todo: React.FC = ({}) => {
             </section>
 
             <div className="pt-3 pb-4 px-3 bg-white dark:bg-navy-900">
+              {!isDesktop && data.labels.length > 0 && (
+                <div className="mb-2">
+                  <MobileLabelFilter
+                    labels={data.labels}
+                    filters={data.filters}
+                    onFilter={updateFilters}
+                  />
+                </div>
+              )}
               <TaskInput
                 placeholder="What needs to be done?"
                 labels={data.labels}


### PR DESCRIPTION
Replaces the top "Showing:" label filter on mobile with a compact
dropdown positioned above the TaskInput. The popover supports
multi-select (stays open on selection), shows a color dot + checkmark
for each label, and includes a "Clear" button to reset all filters.
Desktop keeps the existing inline filter display.
