### PR TITLE
Show active filter labels when mobile dropdown is collapsed

### DIFF
--- a/src/components/MobileLabelFilter.tsx
+++ b/src/components/MobileLabelFilter.tsx
@@ -34,20 +34,43 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
     setOpen(false)
   }
 
+  const activeLabels = labels.filter(l => filters.includes(l.id))
+
   return (
     <div ref={ref} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen(prev => !prev)}
-        className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
-      >
-        <FilterIcon fontSize={12} />
-        <span>{activeCount > 0 ? `Filtering (${activeCount})` : "Filter"}</span>
-        <ChevronDown
-          fontSize={12}
-          className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
-        />
-      </button>
+      <div className="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={() => setOpen(prev => !prev)}
+          className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
+        >
+          <FilterIcon fontSize={12} />
+          <span>Filter</span>
+          <ChevronDown
+            fontSize={12}
+            className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+        {!open && activeLabels.length > 0 && (
+          <>
+            <span className="text-[10px] text-slate-400 dark:text-navy-500">
+              Filtering by:
+            </span>
+            {activeLabels.map(label => (
+              <span
+                key={label.id}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                style={{
+                  backgroundColor: label.color + "22",
+                  color: label.color
+                }}
+              >
+                {label.title}
+              </span>
+            ))}
+          </>
+        )}
+      </div>
 
       {open && (
         <div className="absolute bottom-full left-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">

--- a/src/components/MobileLabelFilter.tsx
+++ b/src/components/MobileLabelFilter.tsx
@@ -38,22 +38,15 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
 
   return (
     <div ref={ref} className="relative">
-      <div className="flex items-center gap-2 flex-wrap">
-        <button
-          type="button"
-          onClick={() => setOpen(prev => !prev)}
-          className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
-        >
-          <FilterIcon fontSize={12} />
-          <span>Filter</span>
-          <ChevronDown
-            fontSize={12}
-            className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
-          />
-        </button>
-        {!open && activeLabels.length > 0 && (
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
+      >
+        <FilterIcon fontSize={12} />
+        {activeLabels.length > 0 ? (
           <>
-            <span className="text-[10px] text-slate-400 dark:text-navy-500">
+            <span className="text-slate-400 dark:text-navy-500">
               Filtering by:
             </span>
             {activeLabels.map(label => (
@@ -69,8 +62,14 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
               </span>
             ))}
           </>
+        ) : (
+          <span>Filter</span>
         )}
-      </div>
+        <ChevronDown
+          fontSize={12}
+          className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
 
       {open && (
         <div className="absolute bottom-full left-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">

--- a/src/components/MobileLabelFilter.tsx
+++ b/src/components/MobileLabelFilter.tsx
@@ -41,9 +41,9 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
       <button
         type="button"
         onClick={() => setOpen(prev => !prev)}
-        className="no-style flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-xs text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
+        className="no-style flex items-center gap-2 px-3 py-2 rounded-lg border border-slate-200/60 dark:border-navy-700/60 text-sm text-slate-500 dark:text-navy-400 transition-colors hover:border-slate-300 dark:hover:border-navy-600"
       >
-        <FilterIcon fontSize={12} />
+        <FilterIcon fontSize={14} />
         {activeLabels.length > 0 ? (
           <>
             <span className="text-slate-400 dark:text-navy-500">
@@ -52,7 +52,7 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
             {activeLabels.map(label => (
               <span
                 key={label.id}
-                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
                 style={{
                   backgroundColor: label.color + "22",
                   color: label.color
@@ -66,28 +66,28 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
           <span>Filter</span>
         )}
         <ChevronDown
-          fontSize={12}
+          fontSize={14}
           className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
         />
       </button>
 
       {open && (
         <div className="absolute bottom-full left-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">
-          <div className="px-3 pt-2.5 pb-1.5 flex items-center justify-between">
-            <span className="text-xs font-medium text-slate-400 dark:text-navy-400 uppercase tracking-wide">
+          <div className="px-3 pt-3 pb-2 flex items-center justify-between">
+            <span className="text-sm font-medium text-slate-400 dark:text-navy-400 uppercase tracking-wide">
               Filter by label
             </span>
             {activeCount > 0 && (
               <button
                 type="button"
                 onClick={clearAll}
-                className="no-style text-xs text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300"
+                className="no-style text-sm text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300"
               >
                 Clear
               </button>
             )}
           </div>
-          <div className="px-1.5 pb-1.5">
+          <div className="px-1.5 pb-2">
             {labels.map(label => {
               const isActive = filters.includes(label.id)
               return (
@@ -95,17 +95,17 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
                   key={label.id}
                   type="button"
                   onClick={() => toggleLabel(label.id)}
-                  className="no-style flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-sm text-slate-700 dark:text-navy-200 hover:bg-slate-50 dark:hover:bg-navy-700/50 transition-colors"
+                  className="no-style flex items-center gap-3 w-full px-2.5 py-2.5 rounded-lg text-base text-slate-700 dark:text-navy-200 hover:bg-slate-50 dark:hover:bg-navy-700/50 transition-colors"
                 >
                   <span
-                    className="w-3 h-3 rounded-full shrink-0"
+                    className="w-3.5 h-3.5 rounded-full shrink-0"
                     style={{ backgroundColor: label.color }}
                   />
                   <span className="flex-1 text-left truncate">
                     {label.title}
                   </span>
                   {isActive && (
-                    <CheckIcon fontSize={14} style={{ color: label.color }} />
+                    <CheckIcon fontSize={16} style={{ color: label.color }} />
                   )}
                 </button>
               )


### PR DESCRIPTION
When the mobile label filter dropdown is closed and filters are active, there's no indication of what's being filtered. This adds small tinted label pills next to the Filter button with "Filtering by:" text, so users can see at a glance which labels are active without opening the popover.

To test, open on mobile (or narrow viewport), select one or more labels from the filter dropdown, then close it — the active labels should appear inline next to the button.