### PR TITLE
Hide delete button on mobile unless edit mode is active

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -272,6 +272,7 @@ const List: React.FC<Props> = ({
                 filters={filters}
                 canPin={canPinTasks}
                 compact={forceCompact || settings.compactMode}
+                editMode={editMode}
               />
             </ReorderableItem>
           ))}

--- a/src/components/Task.tsx
+++ b/src/components/Task.tsx
@@ -26,6 +26,8 @@ interface Props {
   active: boolean
   labels: Record<string, LabelType>
   filters: string[]
+  /** When undefined (desktop), delete button uses hover behavior. When boolean (mobile), controls visibility. */
+  editMode?: boolean
   onFilter: (filters: string[]) => void
   onSelect: (taskId: TaskType["id"], event: FormEvent) => void
   onDeselect: () => void
@@ -90,6 +92,7 @@ const Task: React.FC<Props> = ({
   active,
   labels,
   filters,
+  editMode,
   onFilter,
   onSelect,
   onDeselect,
@@ -452,7 +455,12 @@ const Task: React.FC<Props> = ({
 
               <button
                 type="button"
-                className="no-style remove-icon touch-target overflow-hidden transition-all duration-200 max-w-[44px] opacity-100 md:max-w-0 md:opacity-0 group-hover:max-w-[44px] group-hover:opacity-100"
+                className={cx(
+                  "no-style remove-icon touch-target overflow-hidden transition-all duration-200",
+                  editMode === false
+                    ? "max-w-0 opacity-0 pointer-events-none"
+                    : "max-w-[44px] opacity-100 md:max-w-0 md:opacity-0 group-hover:max-w-[44px] group-hover:opacity-100"
+                )}
                 data-tooltip-id="tooltip"
                 data-tooltip-content="Delete (X)"
                 aria-label="Delete task"

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -607,7 +607,9 @@ const Todo: React.FC = ({}) => {
                     labels={labelsById}
                     filters={data.filters}
                     isFiltering={isFiltering}
-                    editMode={isMobile ? editMode : undefined}
+                    editMode={
+                      isMobile && visibleTasks.length > 1 ? editMode : undefined
+                    }
                     onFilter={updateFilters}
                     onUpdateTask={handleUpdateTask}
                     onRemoveTask={handleRemoveTask}


### PR DESCRIPTION
The X icon on tasks was always visible on mobile, adding visual clutter.
Now the delete button only appears when the user taps the pencil icon to
enter edit mode, which enables both reordering and deleting. When there's
only a single task (no edit button shown), the delete icon remains
accessible via the existing hover/touch behavior.

https://claude.ai/code/session_01Gg2zLybdqBWi4WB6Sr3mG5