### PR TITLE
Right-align mobile filter button and dropdown

### DIFF
--- a/src/components/MobileLabelFilter.tsx
+++ b/src/components/MobileLabelFilter.tsx
@@ -72,7 +72,7 @@ const MobileLabelFilter: React.FC<Props> = ({ labels, filters, onFilter }) => {
       </button>
 
       {open && (
-        <div className="absolute bottom-full left-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">
+        <div className="absolute bottom-full right-0 mb-2 w-56 bg-white dark:bg-navy-800 rounded-xl border border-slate-200/80 dark:border-navy-700/80 shadow-lg dark:shadow-navy-950/40 overflow-hidden z-50">
           <div className="px-3 pt-3 pb-2 flex items-center justify-between">
             <span className="text-sm font-medium text-slate-400 dark:text-navy-400 uppercase tracking-wide">
               Filter by label

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -626,7 +626,7 @@ const Todo: React.FC = ({}) => {
 
             <div className="pt-3 pb-4 px-3 bg-white dark:bg-navy-900">
               {!isDesktop && data.labels.length > 0 && (
-                <div className="mb-2">
+                <div className="mb-2 flex justify-end">
                   <MobileLabelFilter
                     labels={data.labels}
                     filters={data.filters}


### PR DESCRIPTION
Move the mobile label filter to the right side of the screen by adding
flex justify-end to the wrapper and anchoring the dropdown to right-0.

https://claude.ai/code/session_017pCuyqLtaMVH7gaidCUiW9